### PR TITLE
Allow a simple patch facility.

### DIFF
--- a/lib/mini_portile.rb
+++ b/lib/mini_portile.rb
@@ -38,8 +38,8 @@ class MiniPortile
   def patch
     @patch_files.each do |full_path|
       next unless File.exists?(full_path)
-      output "Running patch with #{full_path}..."
-      execute('patch', %Q(patch -p1 < #{full_path}))
+      output "Running git apply with #{full_path}..."
+      execute('patch', %Q(git apply #{full_path}))
     end   
   end
 


### PR DESCRIPTION
The user must supply a full path to the patch files. This makes it easy to support. For instance, I have done the following in my ports.rake file.

``` ruby
$recipes[:freetds].patch_files << File.expand_path(File.join('..', '..', 'ext', 'patch', 'sspi_w_kerberos.diff'), __FILE__)
```
