### PR TITLE
Use patch instead of git-apply.

### DIFF
--- a/lib/mini_portile.rb
+++ b/lib/mini_portile.rb
@@ -38,8 +38,8 @@ class MiniPortile
   def patch
     @patch_files.each do |full_path|
       next unless File.exists?(full_path)
-      output "Running git apply with #{full_path}..."
-      execute('patch', %Q(git apply #{full_path}))
+      output "Running patch with #{full_path}..."
+      execute('patch', %Q(patch -p1 < #{full_path}))
     end
   end
 


### PR DESCRIPTION
When git-apply is run within another git repository it completes successfully,
but does absolutely nothing.

Since mini_portile is typically used to build downloaded tar files
with no git repository inside, but is started by the rake tasks of a git
checkout, it should use patch instead.
