### PR TITLE
Shell escape paths in tar command

### DIFF
--- a/lib/mini_portile.rb
+++ b/lib/mini_portile.rb
@@ -239,7 +239,7 @@ private
     FileUtils.mkdir_p target
 
     message "Extracting #{filename} into #{target}... "
-    result = `#{tar_exe} xf #{file} -C #{target} 2>&1`
+    result = `#{tar_exe} xf "#{file}" -C "#{target}" 2>&1`
     if $?.success?
       output "OK"
     else


### PR DESCRIPTION
This was causing me trouble today and I noticed it hasn't been changed in master yet. Figured I would bring it to your attention.
