### PR TITLE
Expand path to logfile in error message

### DIFF
--- a/lib/mini_portile.rb
+++ b/lib/mini_portile.rb
@@ -275,7 +275,7 @@ private
         output "OK"
         return true
       else
-        output "ERROR, review '#{log}' to see what happened."
+        output "ERROR, review '#{log_out}' to see what happened."
         raise "Failed to complete #{action} task"
       end
     end


### PR DESCRIPTION
The path printed in case something went wrong during the build-process was not the full expanded path. This can be misleading in some situations. Also it's much better to output the full path, so that it can be easily copied directly from the terminal emulator into the editor-open-dialog.
