### PR TITLE
Add gem tasks that were removed in commit a49fc5ec3.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "rake/clean"
+require 'bundler/gem_tasks'
 
 desc "Test MiniPortile by compiling examples"
 task :test do


### PR DESCRIPTION
```gem build mini_portile.gemspec``` works, but most users probably expect a rake task for this.