### PR TITLE
Take configure_options literally, instead of simply join with a space.

### DIFF
--- a/lib/mini_portile/version.rb
+++ b/lib/mini_portile/version.rb
@@ -1,3 +1,3 @@
 class MiniPortile
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
This allows the use of characters within the configure_options, that are
otherwise interpreted by the shell, in particular spaces.

It explicit avoids shellescape because stdlib's shellwords follows Unix rules
only, for shell escaping, but don't work on Windows.

This is syntax compatible and working on Ruby-1.8.7. However it prints, as a
compromise, configure output to stdout/err instead of writing to the log file,
in this case.

This slightly changes the semantics of API, so that it could break some build
scripts, if they do shell escaping to configure options on their own. This is
in particular nokogiri. So this patch is probably something for a 0.7 series.