### PR TITLE
Correct README badges link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MiniPortile
 
 [![travis Status](https://travis-ci.org/flavorjones/mini_portile.svg?branch=master)](https://travis-ci.org/flavorjones/mini_portile)
-[![appveyor status](https://ci.appveyor.com/api/projects/status/pxm0qf21306wet60?svg=true)](https://ci.appveyor.com/project/luislavena/mini-portile)
+[![appveyor status](https://ci.appveyor.com/api/projects/status/rjji6y9uteaw4oua/branch/master?svg=true)](https://ci.appveyor.com/project/flavorjones/mini-portile)
 
 * Documentation: http://www.rubydoc.info/github/flavorjones/mini_portile
 * Source Code: https://github.com/flavorjones/mini_portile

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MiniPortile
 
-![travis status](https://travis-ci.org/flavorjones/mini_portile.svg?branch=master)
-![appveyor status](https://ci.appveyor.com/api/projects/status/rjji6y9uteaw4oua/branch/master?svg=true)
+[![travis Status](https://travis-ci.org/flavorjones/mini_portile.svg?branch=master)](https://travis-ci.org/flavorjones/mini_portile)
+[![appveyor status](https://ci.appveyor.com/api/projects/status/pxm0qf21306wet60?svg=true)](https://ci.appveyor.com/project/luislavena/mini-portile)
 
 * Documentation: http://www.rubydoc.info/github/flavorjones/mini_portile
 * Source Code: https://github.com/flavorjones/mini_portile


### PR DESCRIPTION
The Markdown present in README links to the rendered or cached version of
the badges instead of the build detail pages of Travis CI and AppVeyor.

This corrects the issue for both CI providers.