### PR TITLE
Several improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+sudo: false
 rvm:
   - 1.8.7
   - 1.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Take configure_options literally without running a subshell.
     Please unescape configure_options where you have been doing it yourself.
   * Print last 20 lines of the given log file, for convenience.
+  * Allow SHA1, SHA256 and MD5 hash verification of downloads
 
 * Bugfixes:
   * Fix issue when proxy username/password use escaped characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+=== 0.7.0 / unreleased
+
+* Enhancements:
+  * In patch task, use git(1) or patch(1), whichever is available.
+  * Append outputs to patch.log instead of clobbering it for every patch command.
+  * Take configure_options literally without running a subshell.
+    Please unescape configure_options where you have been doing it yourself.
+  * Print last 20 lines of the given log file, for convenience.
+
+* Bugfixes:
+  * Fix issue when proxy username/password use escaped characters.
+  * Fix use of https and ftp proxy.
+
 ### 0.6.2 / 2014-12-30
 
 * Updated gemspec, license and README to reflect new maintainer.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ Example:
 ```ruby
 task :libiconv do
   recipe = MiniPortile.new("libiconv", "1.13.1")
-  recipe.files = ["http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz"]
+  recipe.files << {
+    url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.13.1.tar.gz"],
+    md5: "7ab33ebd26687c744a37264a330bbe9a"
+  }
   checkpoint = ".#{recipe.name}-#{recipe.version}.installed"
 
   unless File.exist?(checkpoint)
@@ -142,6 +145,7 @@ end
 
 The above example will:
 
+* **download** and verify integrity the sources only once
 * **compile** the library only once (using a timestamp file)
 * ensure compiled library is **activated**
 * make the compile task depend upon compiled library activation

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,20 @@
 require "rake/clean"
 
-desc "Test MiniPortile by compiling examples"
-task :test do
-  Dir.chdir("examples") do
-    sh "rake ports:all"
+namespace :test do
+  desc "Test MiniPortile by running unit tests"
+  task :unit do
+    sh "ruby -w -W2 -I. -Ilib -e \"#{Dir["test/test_*.rb"].map{|f| "require '#{f}';"}.join}\" -- -v"
+  end
+
+  desc "Test MiniPortile by compiling examples"
+  task :examples do
+    Dir.chdir("examples") do
+      sh "rake -I../lib ports:all"
+    end
   end
 end
+
+desc "Run all tests"
+task :test => ["test:unit", "test:examples"]
 
 task :default => [:test]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,15 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
+  - bundle install
 build: off
 test_script:
-  - rake -rdevkit test
+  - bundle exec rake -rdevkit test
 
 environment:
   matrix:
     - ruby_version: "193"
-    - ruby_version: "200"
-    - ruby_version: "200-x64"
-    - ruby_version: "21"
+#    - ruby_version: "200"
+#    - ruby_version: "200-x64"
+#    - ruby_version: "21"
     - ruby_version: "21-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 ---
 version: "{build}"
-branches:
-  only:
-    - master
 clone_depth: 10
 install:
   - ps: ((New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt', "$env:TMP\ca-bundle.crt"))

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -73,7 +73,11 @@ class ZlibRecipe < MiniPortile
 end
 
 zlib = ZlibRecipe.new "zlib", "1.2.8"
-zlib.files << "http://zlib.net/#{zlib.name}-#{zlib.version}.tar.gz"
+zlib.files << {
+  url: "http://zlib.net/#{zlib.name}-#{zlib.version}.tar.gz",
+  md5: "44d667c142d7cda120332623eab69f40",
+}
+
 
 recipes.push zlib
 

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'tempfile'
 require 'digest/md5'
 require 'open-uri'
+require 'cgi'
 
 # Monkey patch for Net::HTTP by ruby open-uri fix:
 # https://github.com/ruby/ruby/commit/58835a9
@@ -402,7 +403,7 @@ private
       if proxy_uri
         _, userinfo, _p_host, _p_port = URI.split(proxy_uri)
         if userinfo
-          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
+          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| CGI.unescape(s) }
           params[:proxy_http_basic_authentication] =
             [proxy_uri, proxy_user, proxy_pass]
         end
@@ -439,7 +440,7 @@ private
       if ENV["ftp_proxy"]
         _, userinfo, _p_host, _p_port = URI.split(ENV['ftp_proxy'])
         if userinfo
-          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
+          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| CGI.unescape(s) }
           params[:proxy_http_basic_authentication] =
             [ENV['ftp_proxy'], proxy_user, proxy_pass]
         end

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -59,17 +59,17 @@ class MiniPortile
       # Not a class variable because closures will capture self.
       @apply_patch ||=
       case
-      when which('patch')
-        lambda { |file|
-          message "Running patch with #{file}... "
-          execute('patch', ["patch", "-p1", "-i", file], :initial_message => false)
-        }
       when which('git')
         lambda { |file|
           message "Running git apply with #{file}... "
           # By --work-tree=. git-apply uses the current directory as
           # the project root and will not search upwards for .git.
           execute('patch', ["git", "--work-tree=.", "apply", file], :initial_message => false)
+        }
+      when which('patch')
+        lambda { |file|
+          message "Running patch with #{file}... "
+          execute('patch', ["patch", "-p1", "-i", file], :initial_message => false)
         }
       else
         raise "Failed to complete patch task; patch(1) or git(1) is required."

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -7,9 +7,11 @@ require 'tempfile'
 require 'digest/md5'
 require 'open-uri'
 
-# Monkey patch for Net::HTTP by ruby open-uri fix(58835a9) apply.
+# Monkey patch for Net::HTTP by ruby open-uri fix:
+# https://github.com/ruby/ruby/commit/58835a9
 class Net::HTTP
   private
+  remove_method(:edit_path)
   def edit_path(path)
     if proxy?
       if path.start_with?("ftp://") || use_ssl?
@@ -79,7 +81,7 @@ class MiniPortile
 
   def patch
     @patch_files.each do |full_path|
-      next unless File.exists?(full_path)
+      next unless File.exist?(full_path)
       apply_patch(full_path)
     end
   end
@@ -374,7 +376,7 @@ private
         download_file_http(url, full_path, count)
       end
     rescue Exception => e
-      File.unlink full_path if File.exists?(full_path)
+      File.unlink full_path if File.exist?(full_path)
       output "ERROR: #{e.message}"
       raise "Failed to complete download task"
     end
@@ -398,7 +400,7 @@ private
                   ENV["https_proxy"] :
                   ENV["http_proxy"]
       if proxy_uri
-        _, userinfo, p_host, p_port = URI.split(proxy_uri)
+        _, userinfo, _p_host, _p_port = URI.split(proxy_uri)
         if userinfo
           proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
           params[:proxy_http_basic_authentication] =
@@ -435,7 +437,7 @@ private
         }
       }
       if ENV["ftp_proxy"]
-        _, userinfo, p_host, p_port = URI.split(ENV['ftp_proxy'])
+        _, userinfo, _p_host, _p_port = URI.split(ENV['ftp_proxy'])
         if userinfo
           proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
           params[:proxy_http_basic_authentication] =
@@ -456,7 +458,7 @@ private
     temp_file.binmode
     yield temp_file
     temp_file.close
-    File.unlink full_path if File.exists?(full_path)
+    File.unlink full_path if File.exist?(full_path)
     FileUtils.mkdir_p File.dirname(full_path)
     FileUtils.mv temp_file.path, full_path, :force => true
   end

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -281,7 +281,7 @@ private
         if command.kind_of?(Array)
           system(*command)
         else
-          redirected = command << " >#{log_out} 2>&1"
+          redirected = "#{command} >#{log_out} 2>&1"
           system(redirected)
         end
       end

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -253,7 +253,14 @@ private
     FileUtils.mkdir_p target
 
     message "Extracting #{filename} into #{target}... "
-    result = `#{tar_exe} #{tar_compression_switch(filename)}xf "#{file}" -C "#{target}" 2>&1`
+    result = if RUBY_VERSION < "1.9"
+      `#{tar_exe} #{tar_compression_switch(filename)}xf "#{file}" -C "#{target}" 2>&1`
+    else
+      IO.popen([tar_exe,
+                "#{tar_compression_switch(filename)}xf", file,
+                "-C", target,
+                {:err=>[:child, :out]}], &:read)
+    end
     if $?.success?
       output "OK"
     else

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -390,11 +390,16 @@ private
           progress = new_progress
         }
       }
-      if ENV["http_proxy"]
-        _, userinfo, p_host, p_port = URI.split(ENV['http_proxy'])
-        proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) } if userinfo
-        params[:proxy_http_basic_authentication] =
-          [ENV['http_proxy'], proxy_user, proxy_pass]
+      proxy_uri = URI.parse(url).scheme.downcase == 'https' ?
+                  ENV["https_proxy"] :
+                  ENV["http_proxy"]
+      if proxy_uri
+        _, userinfo, p_host, p_port = URI.split(proxy_uri)
+        if userinfo
+          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
+          params[:proxy_http_basic_authentication] =
+            [proxy_uri, proxy_user, proxy_pass]
+        end
       end
       begin
         OpenURI.open_uri(url, 'rb', params) do |io|
@@ -427,9 +432,11 @@ private
       }
       if ENV["ftp_proxy"]
         _, userinfo, p_host, p_port = URI.split(ENV['ftp_proxy'])
-        proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) } if userinfo
-        params[:proxy_http_basic_authentication] =
-          [ENV['ftp_proxy'], proxy_user, proxy_pass]
+        if userinfo
+          proxy_user, proxy_pass = userinfo.split(/:/).map{|s| URI.unescape(s) }
+          params[:proxy_http_basic_authentication] =
+            [ENV['ftp_proxy'], proxy_user, proxy_pass]
+        end
       end
       OpenURI.open_uri(uri, 'rb', params) do |io|
         temp_file << io.read

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -382,6 +382,7 @@ private
       progress = 0
       total = 0
       params = {
+        "Accept-Encoding" => 'identity'
         :content_length_proc => lambda{|length| total = length },
         :progress_proc => lambda{|bytes|
           new_progress = (bytes * 100) / total

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -7,6 +7,22 @@ require 'tempfile'
 require 'digest/md5'
 require 'open-uri'
 
+# Monkey patch for Net::HTTP by ruby open-uri fix(58835a9) apply.
+class Net::HTTP
+  private
+  def edit_path(path)
+    if proxy?
+      if path.start_with?("ftp://") || use_ssl?
+        path
+      else
+        "http://#{addr_port}#{path}"
+      end
+    else
+      path
+    end
+  end
+end
+
 class MiniPortile
   attr_reader :name, :version, :original_host
   attr_writer :configure_options

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -331,7 +331,11 @@ private
         output "OK"
         return true
       else
-        output "ERROR, review '#{log_out}' to see what happened."
+        output "ERROR, review '#{log_out}' to see what happened. Last lines are:"
+        output("=" * 72)
+        log_lines = File.readlines(log_out)
+        output(log_lines[-[log_lines.length, 20].min .. -1])
+        output("=" * 72)
         raise "Failed to complete #{action} task"
       end
     end

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -44,8 +44,8 @@ class MiniPortile
     begin
       @patch_files.each do |full_path|
         next unless File.exists?(full_path)
-        output "Running git apply with #{full_path}..."
-        execute('patch', %Q(git apply #{full_path}))
+        output "Running git apply with #{full_path}... "
+        execute('patch', %w(git apply) + [full_path], :initial_message => false)
       end
     ensure
       ENV['GIT_DIR'] = old_git
@@ -60,10 +60,10 @@ class MiniPortile
     return if configured?
 
     md5_file = File.join(tmp_path, 'configure.md5')
-    digest   = Digest::MD5.hexdigest(computed_options)
+    digest   = Digest::MD5.hexdigest(computed_options.to_s)
     File.open(md5_file, "w") { |f| f.write digest }
 
-    execute('configure', %Q(sh configure #{computed_options}))
+    execute('configure', %w(sh configure) + computed_options)
   end
 
   def compile
@@ -90,7 +90,7 @@ class MiniPortile
     md5_file  = File.join(tmp_path, 'configure.md5')
 
     stored_md5  = File.exist?(md5_file) ? File.read(md5_file) : ""
-    current_md5 = Digest::MD5.hexdigest(computed_options)
+    current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
 
     (current_md5 == stored_md5) && newer?(makefile, configure)
   end
@@ -186,7 +186,7 @@ private
     [
       configure_options,     # customized or default options
       configure_prefix,      # installation target
-    ].flatten.join(' ')
+    ].flatten
   end
 
   def log_file(action)
@@ -263,14 +263,29 @@ private
     end
   end
 
-  def execute(action, command)
+  def execute(action, command, options={})
     log        = log_file(action)
     log_out    = File.expand_path(log)
-    redirected = command << " >#{log_out} 2>&1"
 
     Dir.chdir work_path do
-      message "Running '#{action}' for #{@name} #{@version}... "
-      system redirected
+      if options.fetch(:initial_message){ true }
+        message "Running '#{action}' for #{@name} #{@version}... "
+      end
+
+      if Process.respond_to?(:spawn)
+        args = [command].flatten + [{[:out, :err]=>[log_out, "w"]}]
+        pid = spawn(*args)
+        Process.wait(pid)
+      else
+        # Ruby-1.8 compatibility:
+        if command.kind_of?(Array)
+          system(*command)
+        else
+          redirected = command << " >#{log_out} 2>&1"
+          system(redirected)
+        end
+      end
+
       if $?.success?
         output "OK"
         return true

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -366,7 +366,7 @@ private
     if ENV['http_proxy']
       _, userinfo, p_host, p_port = URI.split(ENV['http_proxy'])
       proxy_user, proxy_pass = userinfo.split(/:/) if userinfo
-      http = Net::HTTP.new(uri.host, uri.port, p_host, p_port, proxy_user, proxy_pass)
+      http = Net::HTTP.new(uri.host, uri.port, p_host, p_port, URI.unescape(proxy_user), URI.unescape(proxy_pass))
     else
       http = Net::HTTP.new(uri.host, uri.port)
 

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -382,7 +382,7 @@ private
       progress = 0
       total = 0
       params = {
-        "Accept-Encoding" => 'identity'
+        "Accept-Encoding" => 'identity',
         :content_length_proc => lambda{|length| total = length },
         :progress_proc => lambda{|bytes|
           new_progress = (bytes * 100) / total

--- a/lib/mini_portile/version.rb
+++ b/lib/mini_portile/version.rb
@@ -1,3 +1,3 @@
 class MiniPortile
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end

--- a/mini_portile.gemspec
+++ b/mini_portile.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "minitar", "~> 0.5.4"
 
   spec.required_ruby_version = ">= 1.8.7"
 end

--- a/test/assets/patch 1.diff
+++ b/test/assets/patch 1.diff
@@ -1,0 +1,4 @@
+--- /dev/null
++++ "b/patch 1.txt"
+@@ -0,0 +1,1 @@
++change 1

--- a/test/assets/patch 1.diff
+++ b/test/assets/patch 1.diff
@@ -1,4 +1,7 @@
+diff --git "a/patch 1.txt" "b/patch 1.txt"
+new file mode 100644
+index 0000000..70885e4
 --- /dev/null
 +++ "b/patch 1.txt"
-@@ -0,0 +1,1 @@
+@@ -0,0 +1 @@
 +change 1

--- a/test/assets/test mini portile-1.0.0/configure
+++ b/test/assets/test mini portile-1.0.0/configure
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+ruby -e "p ARGV" -- "$@" > configure.txt
+
+cat <<EOT >Makefile
+all:
+	ruby -e "p ARGV" -- "\$@" > compile.txt
+install:
+	ruby -e "p ARGV" -- "\$@" > install.txt
+EOT

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,14 @@
 require 'test/unit'
+require 'webrick'
+require 'fileutils'
+require 'zlib'
+require 'archive/tar/minitar'
 
 class TestCase < Test::Unit::TestCase
   class << self
     HTTP_PORT = 23523
+
+    attr_accessor :webrick
 
     def start_webrick(path)
       @webrick = WEBrick::HTTPServer.new(:Port => HTTP_PORT, :DocumentRoot => path).tap do |w|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,40 @@
+require 'test/unit'
+
+class TestCase < Test::Unit::TestCase
+  class << self
+    HTTP_PORT = 23523
+
+    def start_webrick(path)
+      @webrick = WEBrick::HTTPServer.new(:Port => HTTP_PORT, :DocumentRoot => path).tap do |w|
+        Thread.new do
+          w.start
+        end
+        until w.status==:Running
+          sleep 0.1
+        end
+      end
+    end
+
+    def stop_webrick
+      if w=@webrick
+        w.shutdown
+        until w.status==:Stop
+          sleep 0.1
+        end
+      end
+    end
+
+    def create_tar(tar_path, assets_path)
+      FileUtils.mkdir_p(File.dirname(tar_path))
+      Zlib::GzipWriter.open(tar_path) do |fdtgz|
+        Dir.chdir(assets_path) do
+          Archive::Tar::Minitar.pack("test mini portile-1.0.0", fdtgz)
+        end
+      end
+    end
+
+    def work_dir(r=recipe)
+      "tmp/#{r.host}/ports/#{r.name}/#{r.version}/#{r.name}-#{r.version}"
+    end
+  end
+end

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -1,8 +1,5 @@
 require File.expand_path('../helper', __FILE__)
-require 'webrick'
 require 'fileutils'
-require 'zlib'
-require 'archive/tar/minitar'
 require 'mini_portile'
 require 'erb'
 

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -1,0 +1,74 @@
+require File.expand_path('../helper', __FILE__)
+require 'webrick'
+require 'fileutils'
+require 'zlib'
+require 'archive/tar/minitar'
+require 'mini_portile'
+require 'erb'
+
+class TestCook < TestCase
+  class << self
+    attr_accessor :assets_path
+    attr_accessor :tar_path
+    attr_accessor :recipe
+
+    def startup
+      @assets_path = File.expand_path("../assets", __FILE__)
+      @tar_path = File.expand_path("../../tmp/test mini portile-1.0.0.tar.gz", __FILE__)
+
+      # remove any previous test files
+      FileUtils.rm_rf("tmp")
+
+      create_tar(@tar_path, @assets_path)
+      start_webrick(File.dirname(@tar_path))
+
+      @recipe = MiniPortile.new("test mini portile", "1.0.0").tap do |recipe|
+        recipe.files << "http://localhost:#{HTTP_PORT}/#{ERB::Util.url_encode(File.basename(@tar_path))}"
+        recipe.patch_files << File.join(@assets_path, "patch 1.diff")
+        recipe.configure_options << "--option=\"path with 'space'\""
+        recipe.cook
+      end
+    end
+
+    def shutdown
+      stop_webrick
+      # leave test files for inspection
+    end
+  end
+
+  def test_download
+    download = "ports/archives/test%20mini%20portile-1.0.0.tar.gz"
+    assert File.exist?(download), download
+  end
+
+  def test_untar
+    configure = File.join(self.class.work_dir, "configure")
+    assert File.exist?(configure), configure
+    assert_match( /^#!\/bin\/sh/, IO.read(configure) )
+  end
+
+  def test_patch
+    patch1 = File.join(self.class.work_dir, "patch 1.txt")
+    assert File.exist?(patch1), patch1
+    assert_match( /^change 1/, IO.read(patch1) )
+  end
+
+  def test_configure
+    txt = File.join(self.class.work_dir, "configure.txt")
+    assert File.exist?(txt), txt
+    opts = self.class.recipe.configure_options + ["--prefix=#{self.class.recipe.path}"]
+    assert_equal( opts.inspect, IO.read(txt).chomp )
+  end
+
+  def test_compile
+    txt = File.join(self.class.work_dir, "compile.txt")
+    assert File.exist?(txt), txt
+    assert_equal( ["all"].inspect, IO.read(txt).chomp )
+  end
+
+  def test_install
+    txt = File.join(self.class.work_dir, "install.txt")
+    assert File.exist?(txt), txt
+    assert_equal( ["install"].inspect, IO.read(txt).chomp )
+  end
+end

--- a/test/test_digest.rb
+++ b/test/test_digest.rb
@@ -1,0 +1,75 @@
+require File.expand_path('../helper', __FILE__)
+require 'fileutils'
+require 'mini_portile'
+require 'erb'
+
+class TestDigest < TestCase
+  class << self
+    attr_accessor :assets_path
+    attr_accessor :tar_path
+    attr_accessor :recipe
+
+    def startup
+      @assets_path = File.expand_path("../assets", __FILE__)
+      @tar_path = File.expand_path("../../tmp/test-digest-1.0.0.tar.gz", __FILE__)
+
+      # remove any previous test files
+      FileUtils.rm_rf("tmp")
+
+      create_tar(@tar_path, @assets_path)
+      start_webrick(File.dirname(@tar_path))
+    end
+
+    def shutdown
+      stop_webrick
+      # leave test files for inspection
+    end
+  end
+
+  def setup
+    # remove any download files
+    FileUtils.rm_rf("ports/archives")
+
+    @recipe = MiniPortile.new("test-digest", "1.0.0")
+  end
+
+  def download_with_digest(key, klass)
+    @recipe.files << {
+      :url => "http://localhost:#{self.class.webrick.config[:Port]}/#{ERB::Util.url_encode(File.basename(self.class.tar_path))}",
+      key => klass.file(self.class.tar_path).hexdigest,
+    }
+    @recipe.download
+  end
+
+  def download_with_wrong_digest(key)
+    @recipe.files << {
+      :url => "http://localhost:#{self.class.webrick.config[:Port]}/#{ERB::Util.url_encode(File.basename(self.class.tar_path))}",
+      key => "0011223344556677",
+    }
+    assert_raise(RuntimeError){ @recipe.download }
+  end
+
+  def test_sha256
+    download_with_digest(:sha256, Digest::SHA256)
+  end
+
+  def test_wrong_sha256
+    download_with_wrong_digest(:sha256)
+  end
+
+  def test_sha1
+    download_with_digest(:sha1, Digest::SHA1)
+  end
+
+  def test_wrong_sha1
+    download_with_wrong_digest(:sha1)
+  end
+
+  def test_md5
+    download_with_digest(:md5, Digest::MD5)
+  end
+
+  def test_wrong_md5
+    download_with_wrong_digest(:md5)
+  end
+end

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -1,23 +1,34 @@
+# Encoding: utf-8
+
 require File.expand_path('../helper', __FILE__)
 require 'fileutils'
 require 'socket'
+require 'erb'
 require 'mini_portile'
 
 class TestProxy < TestCase
-  def with_dummy_proxy
+  def with_dummy_proxy(username=nil, password=nil)
     gs = TCPServer.open('localhost', 0)
     th = Thread.new do
       s = gs.accept
       gs.close
       begin
-        s.gets
+        req = ''
+        while (l=s.gets) && !l.chomp.empty?
+          req << l
+        end
+        req
       ensure
         s.close
       end
     end
 
-    yield "http://localhost:#{gs.addr[1]}"
-
+    if username && password
+      yield "http://#{ERB::Util.url_encode(username)}:#{ERB::Util.url_encode(password)}@localhost:#{gs.addr[1]}"
+    else
+      yield "http://localhost:#{gs.addr[1]}"
+    end
+    
     # Set timeout for reception of the request
     Thread.new do
       sleep 1
@@ -31,15 +42,36 @@ class TestProxy < TestCase
     FileUtils.rm_rf("port/archives")
   end
 
+  def assert_proxy_auth(expected, request)
+    if request =~ /^Proxy-Authorization: Basic (.*)/
+      assert_equal 'user: @name:@12: üMp', $1.unpack("m")[0].force_encoding(__ENCODING__)
+    else
+      flunk "No authentication request"
+    end
+  end
+
   def test_http_proxy
     recipe = MiniPortile.new("test http_proxy", "1.0.0")
     recipe.files << "http://myserver/path/to/tar.gz"
     request = with_dummy_proxy do |url, thread|
       ENV['http_proxy'] = url
-      assert_raise(RuntimeError) { recipe.cook }
+      recipe.download rescue RuntimeError
       ENV.delete('http_proxy')
     end
     assert_match(/GET http:\/\/myserver\/path\/to\/tar.gz/, request)
+  end
+
+  def test_http_proxy_with_basic_auth
+    recipe = MiniPortile.new("test http_proxy", "1.0.0")
+    recipe.files << "http://myserver/path/to/tar.gz"
+    request = with_dummy_proxy('user: @name', '@12: üMp') do |url, thread|
+      ENV['http_proxy'] = url
+      recipe.download  rescue RuntimeError
+      ENV.delete('http_proxy')
+    end
+
+    assert_match(/GET http:\/\/myserver\/path\/to\/tar.gz/, request)
+    assert_proxy_auth 'user: @name:@12: üMp', request
   end
 
   def test_https_proxy
@@ -47,10 +79,23 @@ class TestProxy < TestCase
     recipe.files << "https://myserver/path/to/tar.gz"
     request = with_dummy_proxy do |url, thread|
       ENV['https_proxy'] = url
-      assert_raise(RuntimeError) { recipe.cook }
+      recipe.download  rescue RuntimeError
       ENV.delete('https_proxy')
     end
     assert_match(/CONNECT myserver:443/, request)
+  end
+
+  def test_https_proxy_with_basic_auth
+    recipe = MiniPortile.new("test https_proxy", "1.0.0")
+    recipe.files << "https://myserver/path/to/tar.gz"
+    request = with_dummy_proxy('user: @name', '@12: üMp') do |url, thread|
+      ENV['https_proxy'] = url
+      recipe.download  rescue RuntimeError
+      ENV.delete('https_proxy')
+    end
+
+    assert_match(/CONNECT myserver:443/, request)
+    assert_proxy_auth 'user: @name:@12: üMp', request
   end
 
   def test_ftp_proxy
@@ -58,9 +103,22 @@ class TestProxy < TestCase
     recipe.files << "ftp://myserver/path/to/tar.gz"
     request = with_dummy_proxy do |url, thread|
       ENV['ftp_proxy'] = url
-      assert_raise(RuntimeError) { recipe.cook }
+      recipe.download  rescue RuntimeError
       ENV.delete('ftp_proxy')
     end
     assert_match(/GET ftp:\/\/myserver\/path\/to\/tar.gz/, request)
+  end
+
+  def test_ftp_proxy_with_basic_auth
+    recipe = MiniPortile.new("test ftp_proxy", "1.0.0")
+    recipe.files << "ftp://myserver/path/to/tar.gz"
+    request = with_dummy_proxy('user: @name', '@12: üMp') do |url, thread|
+      ENV['ftp_proxy'] = url
+      recipe.download  rescue RuntimeError
+      ENV.delete('ftp_proxy')
+    end
+
+    assert_match(/GET ftp:\/\/myserver\/path\/to\/tar.gz/, request)
+    assert_proxy_auth 'user: @name:@12: üMp', request
   end
 end

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -1,0 +1,66 @@
+require File.expand_path('../helper', __FILE__)
+require 'fileutils'
+require 'socket'
+require 'mini_portile'
+
+class TestProxy < TestCase
+  def with_dummy_proxy
+    gs = TCPServer.open('localhost', 0)
+    th = Thread.new do
+      s = gs.accept
+      gs.close
+      begin
+        s.gets
+      ensure
+        s.close
+      end
+    end
+
+    yield "http://localhost:#{gs.addr[1]}"
+
+    # Set timeout for reception of the request
+    Thread.new do
+      sleep 1
+      th.kill
+    end
+    th.value
+  end
+
+  def setup
+    # remove any download files
+    FileUtils.rm_rf("port/archives")
+  end
+
+  def test_http_proxy
+    recipe = MiniPortile.new("test http_proxy", "1.0.0")
+    recipe.files << "http://myserver/path/to/tar.gz"
+    request = with_dummy_proxy do |url, thread|
+      ENV['http_proxy'] = url
+      assert_raise(RuntimeError) { recipe.cook }
+      ENV.delete('http_proxy')
+    end
+    assert_match(/GET http:\/\/myserver\/path\/to\/tar.gz/, request)
+  end
+
+  def test_https_proxy
+    recipe = MiniPortile.new("test https_proxy", "1.0.0")
+    recipe.files << "https://myserver/path/to/tar.gz"
+    request = with_dummy_proxy do |url, thread|
+      ENV['https_proxy'] = url
+      assert_raise(RuntimeError) { recipe.cook }
+      ENV.delete('https_proxy')
+    end
+    assert_match(/CONNECT myserver:443/, request)
+  end
+
+  def test_ftp_proxy
+    recipe = MiniPortile.new("test ftp_proxy", "1.0.0")
+    recipe.files << "ftp://myserver/path/to/tar.gz"
+    request = with_dummy_proxy do |url, thread|
+      ENV['ftp_proxy'] = url
+      assert_raise(RuntimeError) { recipe.cook }
+      ENV.delete('ftp_proxy')
+    end
+    assert_match(/GET ftp:\/\/myserver\/path\/to\/tar.gz/, request)
+  end
+end


### PR DESCRIPTION
See CHANGELOG:

* Enhancements:
  * In patch task, use git(1) or patch(1), whichever is available.
  * Append outputs to patch.log instead of clobbering it for every patch command.
  * Take configure_options literally without running a subshell.
    Please unescape configure_options where you have been doing it yourself.
  * Print last 20 lines of the given log file, for convenience.
  * Allow SHA1, SHA256 and MD5 hash verification of downloads

* Bugfixes:
  * Fix issue when proxy username/password use escaped characters.
  * Fix use of https and ftp proxy.

This merges #48 , and fixes some issues of this PR. It fixes #19, #36, #42 and #43. In addition it obsoletes #34, #51 and #52 .

It runs green on appveyor, too: https://ci.appveyor.com/project/larskanis/mini-portile
