### PR TITLE
support gpg signature verification of download resources

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 ---
 install:
+  - ps: ((New-Object Net.WebClient).DownloadFile('ftp://ftp.gnupg.org/gcrypt/binary/libiconv-1.9.1.dll.zip', 'C:\Program Files (x86)\Git\bin\libiconv.zip'))
+  - ps: unzip 'C:\Program Files (x86)\Git\bin\libiconv.zip'
   - ps: ((New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/bagder/ca-bundle/master/ca-bundle.crt', "$env:TMP\ca-bundle.crt"))
   - SET SSL_CERT_FILE=%TMP%\ca-bundle.crt
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%

--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -245,15 +245,31 @@ private
   end
 
   def verify_file(file)
-    digest = case
-      when exp=file[:sha256] then Digest::SHA256
-      when exp=file[:sha1] then Digest::SHA1
-      when exp=file[:md5] then Digest::MD5
-    end
-    if digest
-      is = digest.file(file[:local_path]).hexdigest
-      unless is == exp.downcase
-        raise "Downloaded file '#{file[:local_path]}' has wrong hash: expected: #{exp} is: #{is}"
+    if file.has_key?(:gpg)
+      gpg = file[:gpg]
+
+      sig_file = Tempfile.new('signature')
+      sig_file.write(file[:gpg][:signature])
+      sig_file.close
+
+      raise "key download failed" unless system("gpg --keyserver pgpkeys.mit.edu --recv-key #{gpg[:key]} 2>&1")
+
+      fingerprint     = `gpg --status-fd 1 --fingerprint #{gpg[:key]} 2>&1`
+      key_fingerprint = fingerprint.match(/Key fingerprint = (.*)$/)[1].gsub(/[^A-Z0-9]/, '')
+
+      gpg_status      = `gpg --status-fd 1 --verify #{sig_file.path} #{file[:local_path]} 2>&1`
+      raise "signature mismatch" unless gpg_status.match(/^\[GNUPG:\] VALIDSIG #{key_fingerprint}/)
+    else
+      digest = case
+        when exp=file[:sha256] then Digest::SHA256
+        when exp=file[:sha1] then Digest::SHA1
+        when exp=file[:md5] then Digest::MD5
+      end
+      if digest
+        is = digest.file(file[:local_path]).hexdigest
+        unless is == exp.downcase
+          raise "Downloaded file '#{file[:local_path]}' has wrong hash: expected: #{exp} is: #{is}"
+        end
       end
     end
   end

--- a/test/test_digest.rb
+++ b/test/test_digest.rb
@@ -72,4 +72,84 @@ class TestDigest < TestCase
   def test_wrong_md5
     download_with_wrong_digest(:md5)
   end
+
+  def test_with_valid_gpg_signature
+    key       = "A1C052F8"
+    signature = <<-SIGNATURE
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQEcBAABCAAGBQJV002uAAoJEFIKmZOhwFL41AcH/2VX1/5mD3dAUXfDaYMG92IV
+aA8vHlsvXpCEPfCYBnPGYYFa/P0qPyw6hsWXZhWEGEm+BqZK6dWCLFaxTVTtsjOE
+vhSR+LL+FNxYmGbK2lYq61PDDL45x5Qnhy3WK1e40F7CqmElSfMOjLuCNC7xR9Jc
+zAZ014ADQ5yfH+Ma40K997AxZeCVGU+A5IEHGoZ2i8pyqx0Jhh6cbpC18yHu5ciN
+0o4E4cLSFFckYB3FnUpDowRonBDNUpDRJVKMo5cvvskc/GWVUVomPuWyNGFPPmMJ
+aySUQcOvO67Z14d9E9ziX/E24KWl6xRymmy9VhzawgSmf//3yZVaD6C/8om3qMw=
+=zjw3
+-----END PGP SIGNATURE-----
+    SIGNATURE
+
+    @recipe.files << {
+      :url => "http://nginx.org/download/nginx-1.9.4.tar.gz",
+      :gpg => {
+        :key => key,
+        :signature => signature
+      }
+    }
+    @recipe.download
+  end
+
+  def test_with_invalid_gpg_signature
+    key       = "A1C052F8"
+    signature = <<-SIGNATURE
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQEcBAABCAAGBQJV002uAAoJEFIKmZOhwFL41AcH/2VX1/5mD3dAUXfDaYMG92IV
+AA8vHlsvXpCEPfCYBnPGYYFa/P0qPyw6hsWXZhWEGEm+BqZK6dWCLFaxTVTtsjOE
+vhSR+LL+FNxYmGbK2lYq61PDDL45x5Qnhy3WK1e40F7CqmElSfMOjLuCNC7xR9Jc
+zAZ014ADQ5yfH+Ma40K997AxZeCVGU+A5IEHGoZ2i8pyqx0Jhh6cbpC18yHu5ciN
+0o4E4cLSFFckYB3FnUpDowRonBDNUpDRJVKMo5cvvskc/GWVUVomPuWyNGFPPmMJ
+aySUQcOvO67Z14d9E9ziX/E24KWl6xRymmy9VhzawgSmf//3yZVaD6C/8om3qMw=
+=zjw3
+-----END PGP SIGNATURE-----
+    SIGNATURE
+
+    @recipe.files << {
+      :url => "http://nginx.org/download/nginx-1.9.4.tar.gz",
+      :gpg => {
+        :key => key,
+        :signature => signature
+      }
+    }
+    exception = assert_raise(RuntimeError){ @recipe.download }
+    assert_equal("signature mismatch", exception.message)
+  end
+
+  def test_with_invalid_key
+    key       = "thisisaninvalidkey"
+    signature = <<-SIGNATURE
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v2
+
+iQEcBAABCAAGBQJV002uAAoJEFIKmZOhwFL41AcH/2VX1/5mD3dAUXfDaYMG92IV
+aA8vHlsvXpCEPfCYBnPGYYFa/P0qPyw6hsWXZhWEGEm+BqZK6dWCLFaxTVTtsjOE
+vhSR+LL+FNxYmGbK2lYq61PDDL45x5Qnhy3WK1e40F7CqmElSfMOjLuCNC7xR9Jc
+zAZ014ADQ5yfH+Ma40K997AxZeCVGU+A5IEHGoZ2i8pyqx0Jhh6cbpC18yHu5ciN
+0o4E4cLSFFckYB3FnUpDowRonBDNUpDRJVKMo5cvvskc/GWVUVomPuWyNGFPPmMJ
+aySUQcOvO67Z14d9E9ziX/E24KWl6xRymmy9VhzawgSmf//3yZVaD6C/8om3qMw=
+=zjw3
+-----END PGP SIGNATURE-----
+    SIGNATURE
+
+    @recipe.files << {
+      :url => "http://nginx.org/download/nginx-1.9.4.tar.gz",
+      :gpg => {
+        :key => key,
+        :signature => signature
+      }
+    }
+    exception = assert_raise(RuntimeError){ @recipe.download }
+    assert_equal("key download failed", exception.message)
+  end
 end


### PR DESCRIPTION
This is to support gpg signature verification with mini_protile.

Example usage:

``` ruby
@recipe.files << {
      :url => "http://nginx.org/download/nginx-1.9.4.tar.gz",
      :gpg => {
        :key => 'A1C052F8',
        :signature => <<-SIGNATURE
-----BEGIN PGP SIGNATURE-----
Version: GnuPG v2
iQEcBAABCAAGBQJV002uAAoJEFIKmZOhwFL41AcH/2VX1/5mD3dAUXfDaYMG92IV
AA8vHlsvXpCEPfCYBnPGYYFa/P0qPyw6hsWXZhWEGEm+BqZK6dWCLFaxTVTtsjOE
vhSR+LL+FNxYmGbK2lYq61PDDL45x5Qnhy3WK1e40F7CqmElSfMOjLuCNC7xR9Jc
zAZ014ADQ5yfH+Ma40K997AxZeCVGU+A5IEHGoZ2i8pyqx0Jhh6cbpC18yHu5ciN
0o4E4cLSFFckYB3FnUpDowRonBDNUpDRJVKMo5cvvskc/GWVUVomPuWyNGFPPmMJ
aySUQcOvO67Z14d9E9ziX/E24KWl6xRymmy9VhzawgSmf//3yZVaD6C/8om3qMw=
=zjw3
-----END PGP SIGNATURE-----
SIGNATURE
      }
    }
```

It does rely on downloading the source tarballs from _nginx.org_. This was done because there was no great solution to having a signed tarball and public/private keys just for a test fixutre.
