### PR TITLE
Retry three times on HTTP failure

### DIFF
--- a/lib/mini_portile/mini_portile.rb
+++ b/lib/mini_portile/mini_portile.rb
@@ -431,6 +431,7 @@ private
             [proxy_uri, proxy_user, proxy_pass]
         end
       end
+      retries = 0
       begin
         OpenURI.open_uri(url, 'rb', params) do |io|
           temp_file << io.read
@@ -441,6 +442,9 @@ private
         count = count - 1
         return download_file(redirect.url, full_path, count - 1)
       rescue => e
+        retries = retries + 1
+        (sleep(0.5 * (2 ** retries)); puts "Retry ##{retries} for #{filename}"; retry) if retries <= 3
+
         output e.message
         return false
       end


### PR DESCRIPTION
We are using a rather large combination of recipes, called a meal, in our repo for [compiling PHP](https://github.com/cloudfoundry/binary-builder/blob/master/recipe/php_meal.rb). We were hitting either 500s when downloading the resources, when we added the retry logic it all went away.

With the current test fixtures this was hard to test. Would love to explore setting up fixtures. @flavorjones or @luislavena want to pair?
