### PR TITLE
ignore git ws config when patching

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -68,7 +68,7 @@ class MiniPortile
           message "Running git apply with #{file}... "
           # By --work-tree=. git-apply uses the current directory as
           # the project root and will not search upwards for .git.
-          execute('patch', ["git", "--work-tree=.", "apply", file], :initial_message => false)
+          execute('patch', ["git", "--work-tree=.", "apply", "--whitespace=warn", file], :initial_message => false)
         }
       when which('patch')
         lambda { |file|

--- a/test/assets/git/config
+++ b/test/assets/git/config
@@ -1,0 +1,2 @@
+[core]
+  whitespace=fix,tab-in-indent,-indent-with-non-tab

--- a/test/assets/patch 1.diff
+++ b/test/assets/patch 1.diff
@@ -4,4 +4,4 @@ index 0000000..70885e4
 --- /dev/null
 +++ "b/patch 1.txt"
 @@ -0,0 +1 @@
-+change 1
++	change 1


### PR DESCRIPTION
Avoid e.g. expanding tabs to spaces (which e.g. can break shell scripts
and makefiles) when the user's git config fixes whitespaces by default.