### PR TITLE
add cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
----
+--
 language: ruby
 sudo: false
 rvm:

--- a/lib/mini_portile2.rb
+++ b/lib/mini_portile2.rb
@@ -1,2 +1,3 @@
 require "mini_portile2/version"
 require "mini_portile2/mini_portile"
+require "mini_portile2/mini_portile_cmake"

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -33,6 +33,10 @@ class MiniPortile
   attr_writer :configure_options
   attr_accessor :host, :files, :patch_files, :target, :logger
 
+  def self.windows?
+    RbConfig::CONFIG['target_os'] =~ /mswin|mingw32/
+  end
+
   def initialize(name, version)
     @name = name
     @version = version

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -1,0 +1,28 @@
+require 'mini_portile2/mini_portile'
+
+class MiniPortileCMake < MiniPortile
+  def configure_prefix
+    "-DCMAKE_INSTALL_PREFIX=#{File.expand_path(port_path)}"
+  end
+
+  def configure
+    return if configured?
+
+    md5_file = File.join(tmp_path, 'configure.md5')
+    digest   = Digest::MD5.hexdigest(computed_options.to_s)
+    File.open(md5_file, "w") { |f| f.write digest }
+
+    execute('configure', %w(cmake) + computed_options + ["."])
+  end
+
+  def configured?
+    configure = File.join(work_path, 'configure')
+    makefile  = File.join(work_path, 'CMakefile')
+    md5_file  = File.join(tmp_path, 'configure.md5')
+
+    stored_md5  = File.exist?(md5_file) ? File.read(md5_file) : ""
+    current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
+
+    (current_md5 == stored_md5) && newer?(makefile, configure)
+  end
+end

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -5,6 +5,14 @@ class MiniPortileCMake < MiniPortile
     "-DCMAKE_INSTALL_PREFIX=#{File.expand_path(port_path)}"
   end
 
+  def configure_defaults
+    if MiniPortile.windows?
+      ['-G "NMake Makefiles"']
+    else
+      []
+    end
+  end
+
   def configure
     return if configured?
 
@@ -24,5 +32,10 @@ class MiniPortileCMake < MiniPortile
     current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
 
     (current_md5 == stored_md5) && newer?(makefile, configure)
+  end
+
+  def make_cmd
+    return "nmake" if MiniPortile.windows?
+    super
   end
 end

--- a/test/assets/test-cmake-1.0/CMakeLists.txt
+++ b/test/assets/test-cmake-1.0/CMakeLists.txt
@@ -1,0 +1,7 @@
+# CMakeLists files in this project can
+# refer to the root source directory of the project as ${HELLO_SOURCE_DIR} and
+# to the root binary directory of the project as ${HELLO_BINARY_DIR}.
+cmake_minimum_required (VERSION 2.8.7)
+project (HELLO)
+add_executable (hello hello.c)
+install (TARGETS hello DESTINATION bin)

--- a/test/assets/test-cmake-1.0/hello.c
+++ b/test/assets/test-cmake-1.0/hello.c
@@ -1,0 +1,4 @@
+int main(int argc, char** argv)
+{
+  return 0 ;
+}

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,4 +49,12 @@ class TestCase < Minitest::Test
   def work_dir(r=recipe)
     "tmp/#{r.host}/ports/#{r.name}/#{r.version}/#{r.name}-#{r.version}"
   end
+
+  def with_custom_git_dir(dir)
+    old = ENV['GIT_DIR']
+    ENV['GIT_DIR'] = dir
+    yield
+  ensure
+    ENV['GIT_DIR'] = old
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -37,11 +37,11 @@ class TestCase < Minitest::Test
     end
   end
 
-  def create_tar(tar_path, assets_path)
+  def create_tar(tar_path, assets_path, directory)
     FileUtils.mkdir_p(File.dirname(tar_path))
     Zlib::GzipWriter.open(tar_path) do |fdtgz|
       Dir.chdir(assets_path) do
-        Archive::Tar::Minitar.pack("test mini portile-1.0.0", fdtgz)
+        Archive::Tar::Minitar.pack(directory, fdtgz)
       end
     end
   end

--- a/test/test_cmake.rb
+++ b/test/test_cmake.rb
@@ -1,0 +1,54 @@
+require File.expand_path('../helper', __FILE__)
+
+class TestCMake < TestCase
+  attr_accessor :assets_path, :tar_path, :recipe
+
+  def before_all
+    super
+    @assets_path = File.expand_path("../assets", __FILE__)
+    @tar_path = File.expand_path("../../tmp/test-cmake-1.0.tar.gz", __FILE__)
+
+    # remove any previous test files
+    FileUtils.rm_rf("tmp")
+
+    create_tar(@tar_path, @assets_path, "test-cmake-1.0")
+    start_webrick(File.dirname(@tar_path))
+
+    @recipe = MiniPortileCMake.new("test-cmake", "1.0").tap do |recipe|
+      recipe.files << "http://localhost:#{HTTP_PORT}/#{ERB::Util.url_encode(File.basename(@tar_path))}"
+      recipe.patch_files << File.join(@assets_path, "patch 1.diff")
+      recipe.configure_options << "--option=\"path with 'space'\""
+      git_dir = File.join(@assets_path, "git")
+      with_custom_git_dir(git_dir) do
+        recipe.cook
+      end
+    end
+  end
+
+  def after_all
+    super
+    stop_webrick
+    # leave test files for inspection
+  end
+
+  def test_cmake_inherits_from_base
+    assert(MiniPortileCMake <= MiniPortile)
+  end
+
+  def test_configure
+    cmakecache = File.join(work_dir, "CMakeCache.txt")
+    assert File.exist?(cmakecache), cmakecache
+
+    assert_includes(IO.read(cmakecache), "CMAKE_INSTALL_PREFIX:PATH=#{recipe.path}")
+  end
+
+  def test_compile
+    binary = File.join(work_dir, "hello")
+    assert File.exist?(binary), binary
+  end
+
+  def test_install
+    binary = File.join(recipe.path, "bin", "hello")
+    assert File.exist?(binary), binary
+  end
+end

--- a/test/test_cmake.rb
+++ b/test/test_cmake.rb
@@ -5,6 +5,8 @@ class TestCMake < TestCase
 
   def before_all
     super
+    return if MiniPortile.windows?
+
     @assets_path = File.expand_path("../assets", __FILE__)
     @tar_path = File.expand_path("../../tmp/test-cmake-1.0.tar.gz", __FILE__)
 
@@ -27,6 +29,8 @@ class TestCMake < TestCase
 
   def after_all
     super
+    return if MiniPortile.windows?
+
     stop_webrick
     # leave test files for inspection
   end
@@ -36,6 +40,8 @@ class TestCMake < TestCase
   end
 
   def test_configure
+    skip if MiniPortile.windows?
+
     cmakecache = File.join(work_dir, "CMakeCache.txt")
     assert File.exist?(cmakecache), cmakecache
 
@@ -43,11 +49,15 @@ class TestCMake < TestCase
   end
 
   def test_compile
+    skip if MiniPortile.windows?
+
     binary = File.join(work_dir, "hello")
     assert File.exist?(binary), binary
   end
 
   def test_install
+    skip if MiniPortile.windows?
+
     binary = File.join(recipe.path, "bin", "hello")
     assert File.exist?(binary), binary
   end

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -19,7 +19,7 @@ class TestCook < TestCase
     # remove any previous test files
     FileUtils.rm_rf("tmp")
 
-    create_tar(@tar_path, @assets_path)
+    create_tar(@tar_path, @assets_path, "test mini portile-1.0.0")
     start_webrick(File.dirname(@tar_path))
 
     @recipe = MiniPortile.new("test mini portile", "1.0.0").tap do |recipe|

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -3,14 +3,6 @@ require File.expand_path('../helper', __FILE__)
 class TestCook < TestCase
   attr_accessor :assets_path, :tar_path, :recipe
 
-  def with_custom_git_dir(dir)
-    old = ENV['GIT_DIR']
-    ENV['GIT_DIR'] = dir
-    yield
-  ensure
-    ENV['GIT_DIR'] = old
-  end
-
   def before_all
     super
     @assets_path = File.expand_path("../assets", __FILE__)

--- a/test/test_digest.rb
+++ b/test/test_digest.rb
@@ -16,6 +16,7 @@ class TestDigest < TestCase
   end
 
   def after_all
+    super
     stop_webrick
     # leave test files for inspection
   end

--- a/test/test_digest.rb
+++ b/test/test_digest.rb
@@ -11,7 +11,7 @@ class TestDigest < TestCase
     # remove any previous test files
     FileUtils.rm_rf("tmp")
 
-    create_tar(@tar_path, @assets_path)
+    create_tar(@tar_path, @assets_path, "test mini portile-1.0.0")
     start_webrick(File.dirname(@tar_path))
   end
 


### PR DESCRIPTION
CMake-based projects are similar to autoconf-based projects, except for the `configure` step.

This PR adds experimental support for CMake-based projects.

@larskanis would love to hear your thoughts.