### PR TITLE
Remove MD5 for configure options hashing - it's unnecessary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ### 2.2.0 / unreleased
 
-(2.2.0.rc1 / 2016-03-08)
-
 #### Enhancements
 
+* Remove MD5 hashing of configure options, not avialbale in FIPS mode. (#78)
 * Add experimental support for cmake-based projects.
 * Retry on HTTP failures during downloads. [#63] (Thanks, @jtarchie and @jvshahid!)
 * Support Ruby 2.4 frozen string literals.

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -4,7 +4,7 @@ require 'net/https'
 require 'net/ftp'
 require 'fileutils'
 require 'tempfile'
-require 'digest/md5'
+require 'digest'
 require 'open-uri'
 require 'cgi'
 require 'rbconfig'
@@ -99,9 +99,8 @@ class MiniPortile
   def configure
     return if configured?
 
-    md5_file = File.join(tmp_path, 'configure.md5')
-    digest   = Digest::MD5.hexdigest(computed_options.to_s)
-    File.open(md5_file, "w") { |f| f.write digest }
+    cache_file = File.join(tmp_path, 'configure.options_cache')
+    File.open(cache_file, "w") { |f| f.write computed_options.to_s }
 
     if RUBY_PLATFORM=~/mingw|mswin/
       # Windows doesn't recognize the shebang.
@@ -131,12 +130,12 @@ class MiniPortile
   def configured?
     configure = File.join(work_path, 'configure')
     makefile  = File.join(work_path, 'Makefile')
-    md5_file  = File.join(tmp_path, 'configure.md5')
+    cache_file  = File.join(tmp_path, 'configure.options_cache')
 
-    stored_md5  = File.exist?(md5_file) ? File.read(md5_file) : ""
-    current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
+    stored_options  = File.exist?(cache_file) ? File.read(cache_file) : ""
+    current_options = computed_options.to_s
 
-    (current_md5 == stored_md5) && newer?(makefile, configure)
+    (current_options == stored_options) && newer?(makefile, configure)
   end
 
   def installed?

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -16,9 +16,8 @@ class MiniPortileCMake < MiniPortile
   def configure
     return if configured?
 
-    md5_file = File.join(tmp_path, 'configure.md5')
-    digest   = Digest::MD5.hexdigest(computed_options.to_s)
-    File.open(md5_file, "w") { |f| f.write digest }
+    cache_file = File.join(tmp_path, 'configure.options_cache')
+    File.open(cache_file, "w") { |f| f.write computed_options.to_s }
 
     execute('configure', %w(cmake) + computed_options + ["."])
   end
@@ -26,12 +25,12 @@ class MiniPortileCMake < MiniPortile
   def configured?
     configure = File.join(work_path, 'configure')
     makefile  = File.join(work_path, 'CMakefile')
-    md5_file  = File.join(tmp_path, 'configure.md5')
+    cache_file  = File.join(tmp_path, 'configure.options_cache')
 
-    stored_md5  = File.exist?(md5_file) ? File.read(md5_file) : ""
-    current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
+    stored_options  = File.exist?(cache_file) ? File.read(cache_file) : ""
+    current_options = computed_options.to_s
 
-    (current_md5 == stored_md5) && newer?(makefile, configure)
+    (current_options == stored_options) && newer?(makefile, configure)
   end
 
   def make_cmd


### PR DESCRIPTION
MD5 is no longer available in environments with strict security settings
especially when running in FIPS mode.

Fixes #78