### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Simplistic port-like solution for developers"
   spec.description = "Simplistic port-like solution for developers. It provides a standard and simplified way to compile against dependency libraries without messing up your system."
 
-  spec.homepage = "http://github.com/flavorjones/mini_portile"
+  spec.homepage = "https://github.com/flavorjones/mini_portile"
   spec.licenses = ["MIT"]
 
   begin


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/mini_portile or some tools or APIs that use the gem's metadata.