### PR TITLE
ci: add 2.3 and 2.4 to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "head"]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "head"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: configure git crlf on windows


### PR DESCRIPTION
these were removed in 87fd0b0 but are still supported according to the
gemspec.