### PR TITLE
add source directory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## mini_portile changelog
 
+### next / unreleased
+
+### Added
+
+Recipes may build against a local directory by specifying `source_directory` instead of `files`. In
+particular, this may be useful for debugging problems with the upstream dependency (e.g., use `git
+bisect` in a local clone).
+
+
 ### 2.5.2 / 2021-05-28
 
 #### Dependencies

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ system-wide installation.
 Same as above, but instead of `MiniPortile.new`, call `MiniPortileCMake.new`.
 
 
+### Local source directories
+
+Instead of downloading a remote file, you can also point mini_portile2 at a local source
+directory. In particular, this may be useful for testing or debugging:
+
+``` ruby
+gem "mini_portile2", "~> 2.0.0" # NECESSARY if used in extconf.rb. see below.
+require "mini_portile2"
+recipe = MiniPortile.new("libiconv", "1.13.1")
+recipe.source_directory = "/path/to/local/source/for/library-1.2.3"
+```
+
 ### Directory Structure Conventions
 
 `mini_portile2` follows the principle of **convention over configuration** and

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -104,16 +104,18 @@ recipes.push zlib
 namespace :ports do
   directory "ports"
 
+  task :before do
+    FileUtils.rm_rf(File.expand_path("tmp"), verbose: true);
+    recipes.each do |recipe|
+      FileUtils.rm_rf(recipe.path, verbose: true)
+    end
+  end
+  task :all => :before
+
   recipes.each do |recipe|
     desc "Install port #{recipe.name} #{recipe.version}"
     task recipe.name => ["ports"] do |t|
-      checkpoint = "ports/.#{recipe.name}-#{recipe.version}-#{recipe.host}.installed"
-
-      unless File.exist?(checkpoint)
-        recipe.cook
-        touch checkpoint
-      end
-
+      recipe.cook
       recipe.activate
     end
 

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -113,3 +113,32 @@ class TestCookWithBrokenGitDir < TestCase
     end
   end
 end
+
+class TestCookAgainstSourceDirectory < TestCase
+  attr_accessor :recipe
+
+  def setup
+    super
+
+    @recipe ||= MiniPortile.new("test mini portile", "1.0.0").tap do |recipe|
+      recipe.source_directory = File.expand_path("../assets/test mini portile-1.0.0", __FILE__)
+    end
+  end
+
+  def test_source_directory
+    recipe.cook
+
+    path = File.join(work_dir, "configure.txt")
+    assert(File.exist?(path))
+    assert_equal((recipe.configure_options + ["--prefix=#{recipe.path}"]).inspect,
+                 File.read(path).chomp);
+
+    path = File.join(work_dir, "compile.txt")
+    assert(File.exist?(path))
+    assert_equal("[\"all\"]", File.read(path).chomp);
+
+    path = File.join(work_dir, "install.txt")
+    assert(File.exist?(path))
+    assert_equal("[\"install\"]", File.read(path).chomp);
+  end
+end


### PR DESCRIPTION
`Recipe#source_directory` allows recipes to build against a local source directory instead of pulling down remote tarballs.