### PR TITLE
address net-ftp warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## mini_portile changelog
 
+### 2.5.3 / unreleased
+
+Make `net-ftp` an optional dependency, since requiring it as a hard dependency in v2.5.2 caused warnings to be emitted by Ruby 2.7 and earlier. A warning message is emitted if FTP functionality is called and `net-ftp` isn't available; this should only happen in Ruby 3.1 and later.
+
+
 ### 2.5.2 / 2021-05-28
 
 #### Dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem "net-ftp" if Gem::Requirement.new("> 3.1.0.dev").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+
 # Specify your gem's dependencies in mini_portile2.gemspec
 gemspec

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -473,7 +473,6 @@ private
   def download_file_http(url, full_path, count = 3)
     filename = File.basename(full_path)
     with_tempfile(filename, full_path) do |temp_file|
-      progress = 0
       total = 0
       params = {
         "Accept-Encoding" => 'identity',
@@ -482,7 +481,6 @@ private
           if total
             new_progress = (bytes * 100) / total
             message "\rDownloading %s (%3d%%) " % [filename, new_progress]
-            progress = new_progress
           else
             # Content-Length is unavailable because Transfer-Encoding is chunked
             message "\rDownloading %s " % [filename]
@@ -532,14 +530,12 @@ private
   def download_file_ftp(uri, full_path)
     filename = File.basename(uri.path)
     with_tempfile(filename, full_path) do |temp_file|
-      progress = 0
       total = 0
       params = {
         :content_length_proc => lambda{|length| total = length },
         :progress_proc => lambda{|bytes|
           new_progress = (bytes * 100) / total
           message "\rDownloading %s (%3d%%) " % [filename, new_progress]
-          progress = new_progress
         }
       }
       if ENV["ftp_proxy"]

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -1,7 +1,6 @@
 require 'rbconfig'
 require 'net/http'
 require 'net/https'
-require 'net/ftp'
 require 'fileutils'
 require 'tempfile'
 require 'digest'
@@ -528,6 +527,7 @@ private
   end
 
   def download_file_ftp(uri, full_path)
+    require "net/ftp"
     filename = File.basename(uri.path)
     with_tempfile(filename, full_path) do |temp_file|
       total = 0
@@ -551,6 +551,8 @@ private
       end
       output
     end
+  rescue LoadError
+    raise LoadError, "Ruby #{RUBY_VERSION} does not provide the net-ftp gem, please add it as a dependency if you need to use FTP"
   rescue Net::FTPError
     return false
   end

--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "net-ftp", "~> 0.1"
-
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "minitar", "~> 0.7"
   spec.add_development_dependency "minitest", "~> 5.11"

--- a/test/test_download.rb
+++ b/test/test_download.rb
@@ -18,10 +18,12 @@ describe "recipe download" do
       end
     end
 
-    block.call
-
-    thread.kill
-    server.close
+    begin
+      block.call
+    ensure
+      thread.kill
+      server.close
+    end
 
     request_count.must_be :>, 0
   end


### PR DESCRIPTION
v2.5.2 added `net-ftp` as a gem dependency to try to anticipate Ruby 3.1 changes.

However, for users of Ruby 2.7 and earlier, this resulted in warnings as demonstrated at #105.

This change makes `net-ftp` an optional (or "soft") dependency, so that if it's loaded the FTP functionality works; but if it's not loaded then an exception is raised informing the user what's wrong.
