### PR TITLE
cmake: Support cmake command replacement on #initialize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Continuous Integration
-
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   push:
@@ -20,6 +22,7 @@ jobs:
     env:
       MAKEFLAGS: -j2
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
         ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "head"]
@@ -43,6 +46,7 @@ jobs:
     env:
       MAKEFLAGS: -j2
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest]
         ruby: ["3.0"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## mini_portile changelog
 
+### next-minor / unreleased
+
+### Added
+
+The commands used for "make", "compile", and "cmake" are configurable via keyword arguments. [#107] (Thanks, @cosmo0920!)
+
+
 ### 2.6.1 / 2021-05-31
 
 #### Dependencies

--- a/README.md
+++ b/README.md
@@ -83,11 +83,60 @@ library into a namespaced structure.
 `#activate` ensures GCC will find this library and prefer it over a
 system-wide installation.
 
+Some keyword arguments can be passed to the constructor to configure the commands used:
+
+#### `gcc_command`
+
+The compiler command that is used is configurable, and in order of preference will use:
+
+- the `CC` environment variable (if present)
+- the `gcc_command` value passed in to the constructor
+- `RbConfig::CONFIG["CC"]`
+- `"gcc"`
+
+You can pass it in like so:
+
+``` ruby
+MiniPortile.new("libiconv", "1.13.1", gcc_command: "cc")
+```
+
+#### `make_command`
+
+The configuration/make command that is used is configurable, and in order of preference will use:
+
+- the `MAKE` environment variable (if present)
+- the `make_command` value passed in to the constructor
+- the `make` environment variable (if present)
+- `"make"`
+
+You can pass it in like so:
+
+``` ruby
+MiniPortile.new("libiconv", "1.13.1", make_command: "nmake")
+```
+
 
 ### How to use (for cmake projects)
 
 Same as above, but instead of `MiniPortile.new`, call `MiniPortileCMake.new`.
 
+#### `make_command`
+
+This is configurable as above, except for Windows systems where it's hardcoded to `"nmake"`.
+
+#### `cmake_command`
+
+The cmake command used is configurable, and in order of preference will use:
+
+- the `CMAKE` environment variable (if present)
+- the `cmake_command` value passed in to the constructor
+- `"cmake"`
+
+You can pass it in like so:
+
+``` ruby
+MiniPortileCMake.new("libfoobar", "1.3.5", cmake_command: "cmake3")
+```
 
 ### Local source directories
 

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -46,7 +46,7 @@ class MiniPortile
     RbConfig::CONFIG['target_os'] =~ /mswin/
   end
 
-  def initialize(name, version)
+  def initialize(name, version, **kwargs)
     @name = name
     @version = version
     @target = 'ports'
@@ -57,6 +57,9 @@ class MiniPortile
     @source_directory = nil
 
     @original_host = @host = detect_host
+
+    @gcc_command = kwargs[:gcc_command]
+    @make_command = kwargs[:make_command]
   end
 
   def source_directory=(path)
@@ -220,6 +223,14 @@ class MiniPortile
 
   def path
     File.expand_path(port_path)
+  end
+
+  def gcc_cmd
+    (ENV["CC"] || @gcc_command || RbConfig::CONFIG["CC"] || "gcc").dup
+  end
+
+  def make_cmd
+    (ENV["MAKE"] || @make_command || ENV["make"] || "make").dup
   end
 
 private
@@ -582,15 +593,5 @@ private
     File.unlink full_path if File.exist?(full_path)
     FileUtils.mkdir_p File.dirname(full_path)
     FileUtils.mv temp_file.path, full_path, :force => true
-  end
-
-  def gcc_cmd
-    cc = ENV["CC"] || RbConfig::CONFIG["CC"] || "gcc"
-    return cc.dup
-  end
-
-  def make_cmd
-    m = ENV['MAKE'] || ENV['make'] || 'make'
-    return m.dup
   end
 end

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -5,6 +5,11 @@ class MiniPortileCMake < MiniPortile
     "-DCMAKE_INSTALL_PREFIX=#{File.expand_path(port_path)}"
   end
 
+  def initialize(name, version, **kwargs)
+    super(name, version, **kwargs)
+    @cmake_command = kwargs[:cmake_command]
+  end
+
   def configure_defaults
     if MiniPortile.mswin?
       ['-G', 'NMake Makefiles']
@@ -21,7 +26,7 @@ class MiniPortileCMake < MiniPortile
     cache_file = File.join(tmp_path, 'configure.options_cache')
     File.open(cache_file, "w") { |f| f.write computed_options.to_s }
 
-    execute('configure', %w(cmake) + computed_options + ["."])
+    execute('configure', [cmake_cmd] + computed_options + ["."])
   end
 
   def configured?
@@ -38,5 +43,9 @@ class MiniPortileCMake < MiniPortile
   def make_cmd
     return "nmake" if MiniPortile.mswin?
     super
+  end
+
+  def cmake_cmd
+    (ENV["CMAKE"] || @cmake_command || "cmake").dup
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -57,4 +57,20 @@ class TestCase < Minitest::Test
   ensure
     ENV['GIT_DIR'] = old
   end
+
+  def with_env(env)
+    before = ENV.to_h.dup
+    env.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    ENV.replace(before)
+  end
+
+  def without_env(*keys, &blk)
+    before = ENV.to_h.dup
+    keys.flatten.each { |k| ENV.delete(k) }
+    yield
+  ensure
+    ENV.replace(before)
+  end
 end

--- a/test/test_cmake.rb
+++ b/test/test_cmake.rb
@@ -58,3 +58,33 @@ class TestCMake < TestCase
     assert File.exist?(binary), binary
   end
 end
+
+class TestCMakeConfig < TestCase
+  def test_make_command_configuration
+    MiniPortile.stub(:mswin?, false) do
+      without_env("MAKE") do
+        assert_equal("make", MiniPortileCMake.new("test", "1.0.0").make_cmd)
+        assert_equal("xyzzy", MiniPortileCMake.new("test", "1.0.0", make_command: "xyzzy").make_cmd)
+      end
+      with_env("MAKE"=>"asdf") do
+        assert_equal("asdf", MiniPortileCMake.new("test", "1.0.0").make_cmd)
+        assert_equal("asdf", MiniPortileCMake.new("test", "1.0.0", make_command: "xyzzy").make_cmd)
+      end
+    end
+
+    MiniPortile.stub(:mswin?, true) do
+      assert_equal("nmake", MiniPortileCMake.new("test", "1.0.0").make_cmd)
+    end
+  end
+
+  def test_cmake_command_configuration
+    without_env("CMAKE") do
+      assert_equal("cmake", MiniPortileCMake.new("test", "1.0.0").cmake_cmd)
+      assert_equal("xyzzy", MiniPortileCMake.new("test", "1.0.0", cmake_command: "xyzzy").cmake_cmd)
+    end
+    with_env("CMAKE"=>"asdf") do
+      assert_equal("asdf", MiniPortileCMake.new("test", "1.0.0").cmake_cmd)
+      assert_equal("asdf", MiniPortileCMake.new("test", "1.0.0", cmake_command: "xyzzy").cmake_cmd)
+    end
+  end
+end

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -67,6 +67,32 @@ class TestCook < TestCase
   end
 end
 
+class TestCookConfiguration < TestCase
+  def test_make_command_configuration
+    without_env("MAKE") do
+      assert_equal("make", MiniPortile.new("test", "1.0.0").make_cmd)
+      assert_equal("xyzzy", MiniPortile.new("test", "1.0.0", make_command: "xyzzy").make_cmd)
+    end
+    with_env("MAKE"=>"asdf") do
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0").make_cmd)
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0", make_command: "xyzzy").make_cmd)
+    end
+  end
+
+  def test_gcc_command_configuration
+    without_env("CC") do
+      expected_compiler = RbConfig::CONFIG["CC"] || "gcc"
+      assert_equal(expected_compiler, MiniPortile.new("test", "1.0.0").gcc_cmd)
+      assert_equal("xyzzy", MiniPortile.new("test", "1.0.0", gcc_command: "xyzzy").gcc_cmd)
+    end
+    with_env("CC"=>"asdf") do
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0").gcc_cmd)
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0", gcc_command: "xyzzy").gcc_cmd)
+    end
+  end
+end
+
+
 class TestCookWithBrokenGitDir < TestCase
   #
   #  this is a test for #69


### PR DESCRIPTION
For CentOS, RHEL, and Amazon Linux 2 use case, we sometimes need to use `cmake3` command instead of `cmake` command.
Could you provide how to specify arbitrary cmake command at `#initialize` on `MiniPortileCMake` class?

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>