### PR TITLE
Add some useful outputs to debug errors

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -527,6 +527,8 @@ private
       end
 
       begin
+        output "Downloading file from #{url}"
+        output "Downloading file with parameters #{params}"
         OpenURI.open_uri(url, 'rb', params) do |io|
           temp_file << io.read
         end
@@ -542,8 +544,13 @@ private
           sleep 1
           return download_file_http(url, full_path, count)
         end
-
-        output e.message
+        if e.kind_of?(OpenURI::HTTPError)
+          response = e.io
+          output "Response status is #{response.status}"
+          output "Response is #{response.read}"
+        else
+          output "Error: #{e.message}"
+        end
         return false
       end
     end


### PR DESCRIPTION
Add outputs to the `download_file_http` function:

- Print the URL from which the file is downloaded.
- Print the parameters of the HTTP Call.
- In the case there is an HTTP error, print the status and the body of it.