### PR TITLE
ci: add darwin coverage to the ci matrix, specify timeouts on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
         ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "head"]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
         ruby: ["3.1"]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## mini_portile changelog
 
+### 2.8.0 / unreleased
+
+#### Added
+
+- When downloading a source archive, explicitly set open_timeout and read_timeout to 10 seconds.
+- Allow configuration of open_timeout and read_timeout.
+
+
 ### 2.7.1 / 2021-10-20
 
 #### Packaging

--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ You can pass it in like so:
 MiniPortile.new("libiconv", "1.13.1", make_command: "nmake")
 ```
 
+#### `open_timeout`, `read_timeout`
+
+By default, when downloading source archives, MiniPortile will use a timeout value of 10
+seconds. This can be overridden by passing a different value (in seconds):
+
+``` ruby
+MiniPortile.new("libiconv", "1.13.1", open_timeout: 99, read_timeout: 2)
+```
+
 
 ### How to use (for cmake projects)
 
@@ -137,6 +146,7 @@ You can pass it in like so:
 ``` ruby
 MiniPortileCMake.new("libfoobar", "1.3.5", cmake_command: "cmake3")
 ```
+
 
 ### Local source directories
 

--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -33,10 +33,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "minitar", "~> 0.7"
-  spec.add_development_dependency "minitest", "~> 5.11"
-  spec.add_development_dependency "minitest-hooks", "~> 1.5.0"
+  spec.add_development_dependency "bundler", "~> 2.3"
+  spec.add_development_dependency "minitar", "~> 0.9"
+  spec.add_development_dependency "minitest", "~> 5.15"
+  spec.add_development_dependency "minitest-hooks", "~> 1.5"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "webrick", "~> 1.0"
+  spec.add_development_dependency "webrick", "~> 1.7"
 end


### PR DESCRIPTION
This PR started as a change adding Darwin builds to CI.

However, I noticed that Windows 3.1 and head builds were really slow, and looking at the logs I can see that it's because it takes 2 minutes to timeout on failed downloads. So I added a feature whereby timeouts can be specifed, and default to 10 seconds.