### PR TITLE
dep(dev): loosen bundler dependency

### DIFF
--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_development_dependency "bundler", "~> 2.3"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "minitar", "~> 0.9"
   spec.add_development_dependency "minitest", "~> 5.15"
   spec.add_development_dependency "minitest-hooks", "~> 1.5"


### PR DESCRIPTION
because windows 3.0 ships with bundler 2.2 and is failing in CI