### PR TITLE
fix: handle patching in dirs that resemble an actual git dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## mini_portile changelog
 
+### next / unreleased
+
+#### Fixed
+
+- Support applying patches via `git apply` even when the working directory resembles a git directory. [#119] (Thanks, @h0tw1r3!)
+
+
 ### 2.8.0 / 2022-02-20
 
 #### Added

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -99,9 +99,9 @@ class MiniPortile
       when which('git')
         lambda { |file|
           message "Running git apply with #{file}... "
-          # By --work-tree=. git-apply uses the current directory as
-          # the project root and will not search upwards for .git.
-          execute('patch', ["git", "--git-dir=.", "--work-tree=.", "apply", "--whitespace=warn", file], :initial_message => false)
+          Dir.mktmpdir do |tmp_git_dir|
+            execute('patch', ["git", "--git-dir=#{tmp_git_dir}", "--work-tree=.", "apply", "--whitespace=warn", file], :initial_message => false)
+          end
         }
       when which('patch')
         lambda { |file|


### PR DESCRIPTION
Fixes #119

cc @h0tw1r3 who has a co-author credit on this one

Note that #121 introduced some tests that exercise patching.