### PR TITLE
[cmake] Automatically add required cross-compilation variables

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -35,17 +35,45 @@ class MiniPortile
   attr_accessor :host, :files, :patch_files, :target, :logger, :source_directory
 
   def self.windows?
-    RbConfig::CONFIG['target_os'] =~ /mswin|mingw/
+    target_os =~ /mswin|mingw/
   end
 
   # GNU MinGW compiled Ruby?
   def self.mingw?
-    RbConfig::CONFIG['target_os'] =~ /mingw/
+    target_os =~ /mingw/
   end
 
   # MS Visual-C compiled Ruby?
   def self.mswin?
-    RbConfig::CONFIG['target_os'] =~ /mswin/
+    target_os =~ /mswin/
+  end
+
+  def self.darwin?
+    target_os =~ /darwin/
+  end
+
+  def self.freebsd?
+    target_os =~ /freebsd/
+  end
+
+  def self.openbsd?
+    target_os =~ /openbsd/
+  end
+
+  def self.linux?
+    target_os =~ /linux/
+  end
+
+  def self.solaris?
+    target_os =~ /solaris/
+  end
+
+  def self.target_os
+    RbConfig::CONFIG['target_os']
+  end
+
+  def self.target_cpu
+    RbConfig::CONFIG['target_cpu']
   end
 
   def initialize(name, version, **kwargs)

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -2,6 +2,8 @@ require 'mini_portile2/mini_portile'
 require 'open3'
 
 class MiniPortileCMake < MiniPortile
+  attr_accessor :system_name
+
   def configure_prefix
     "-DCMAKE_INSTALL_PREFIX=#{File.expand_path(port_path)}"
   end
@@ -12,13 +14,10 @@ class MiniPortileCMake < MiniPortile
   end
 
   def configure_defaults
-    if MiniPortile.mswin? && generator_available?('NMake')
-      ['-G', 'NMake Makefiles']
-    elsif MiniPortile.mingw? && generator_available?('MSYS')
-      ['-G', 'MSYS Makefiles']
-    else
-      []
-    end
+    [
+      generator_defaults,
+      cmake_compile_flags,
+    ].flatten
   end
 
   def configure
@@ -51,6 +50,77 @@ class MiniPortileCMake < MiniPortile
   end
 
   private
+
+  def generator_defaults
+    if MiniPortile.mswin? && generator_available?('NMake')
+      ['-G', 'NMake Makefiles']
+    elsif MiniPortile.mingw? && generator_available?('MSYS')
+      ['-G', 'MSYS Makefiles']
+    else
+      []
+    end
+  end
+
+  def cmake_compile_flags
+    c_compiler, cxx_compiler = find_c_and_cxx_compilers(host)
+
+    # needed to ensure cross-compilation with CMake targets the right CPU and compilers
+    [
+      "-DCMAKE_SYSTEM_NAME=#{cmake_system_name}",
+      "-DCMAKE_SYSTEM_PROCESSOR=#{MiniPortile.target_cpu}",
+      "-DCMAKE_C_COMPILER=#{c_compiler}",
+      "-DCMAKE_CXX_COMPILER=#{cxx_compiler}"
+    ]
+  end
+
+  def find_compiler(compilers)
+    compilers.find { |binary| which(binary) }
+  end
+
+  # configure automatically searches for the right compiler based on the
+  # `--host` parameter.  However, CMake doesn't have an equivalent feature.
+  # Search for the right compiler for the target architecture using
+  # some basic heruistics.
+  def find_c_and_cxx_compilers(host)
+    c_compiler = ENV["CC"]
+    cxx_compiler = ENV["CXX"]
+
+    if MiniPortile.darwin?
+      c_compiler ||= 'clang'
+      cxx_compiler ||='clang++'
+    else
+      c_compiler ||= 'gcc'
+      cxx_compiler ||= 'g++'
+    end
+
+    c_platform_compiler = "#{host}-#{c_compiler}"
+    cxx_platform_compiler = "#{host}-#{cxx_compiler}"
+    c_compiler = find_compiler([c_platform_compiler, c_compiler])
+    cxx_compiler = find_compiler([cxx_platform_compiler, cxx_compiler])
+
+    [c_compiler, cxx_compiler]
+  end
+
+  # Full list: https://gitlab.kitware.com/cmake/cmake/-/blob/v3.26.4/Modules/CMakeDetermineSystem.cmake?ref_type=tags#L12-31
+  def cmake_system_name
+    return system_name if system_name
+
+    if MiniPortile.linux?
+      'Linux'
+    elsif MiniPortile.darwin?
+      'Darwin'
+    elsif MiniPortile.windows?
+      'Windows'
+    elsif MiniPortile.freebsd?
+      'FreeBSD'
+    elsif MiniPortile.openbsd?
+      'OpenBSD'
+    elsif MiniPortile.solaris?
+      'SunOS'
+    else
+      raise "Unable to set CMAKE_SYSTEM_NAME for #{MiniPortile.target_os}"
+    end
+  end
 
   def generator_available?(generator_type)
     stdout_str, status = Open3.capture2("#{cmake_cmd} --help")

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -67,7 +67,7 @@ class MiniPortileCMake < MiniPortile
     # needed to ensure cross-compilation with CMake targets the right CPU and compilers
     [
       "-DCMAKE_SYSTEM_NAME=#{cmake_system_name}",
-      "-DCMAKE_SYSTEM_PROCESSOR=#{MiniPortile.target_cpu}",
+      "-DCMAKE_SYSTEM_PROCESSOR=#{cpu_type}",
       "-DCMAKE_C_COMPILER=#{c_compiler}",
       "-DCMAKE_CXX_COMPILER=#{cxx_compiler}"
     ]
@@ -128,5 +128,11 @@ class MiniPortileCMake < MiniPortile
     raise 'Unable to determine whether CMake supports #{generator_type} Makefile generator' unless status.success?
 
     stdout_str.include?("#{generator_type} Makefiles")
+  end
+
+  def cpu_type
+    return 'x86_64' if MiniPortile.target_cpu == 'x64'
+
+    MiniPortile.target_cpu
   end
 end


### PR DESCRIPTION
For the standard `make`, mini_portile provides the `configure` script with the `--host` parameter, and the script figures out the target compilers to use. With CMake, we don't have that benefit so we need to set the C and C++ compilers ourselves.

This commit uses a simple heuristic to find the target compilers:

1. For macOS, use `clang` and `clang++`. Otherwise use `gcc` and `gcc++`.
2. We search the PATH for `<host>-compiler`. Use that if we find it. Otherwise default to the base compilers.

To make CMake work with cross-compilation, a number of variables have to be set:

- CMAKE_SYSTEM_PROCESSOR
- CMAKE_SYSTEM_NAME
- CMAKE_C_COMPILER
- CMAKE_CXX_COMPILER

Closes #128