### PR TITLE
improve mkmf config

### DIFF
--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -128,18 +128,19 @@ yaml.files = [{
                 url: "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
                 sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4",
               }]
+yaml.configure_options << "CFLAGS=-fPIC"
 recipes.unshift(yaml)
 recipe_hooks["yaml"] = lambda do |recipe|
-  recipe.mkmf_config(pkg: "yaml-0.1")
+  recipe.mkmf_config(pkg: "yaml-0.1", static: "yaml")
 
-  expected = File.join(recipe.path, "lib")
-  $LIBPATH.include?(expected) or raise(<<~MSG)
-    assertion failed: $LIBPATH not updated correctly:
-    #{$LIBPATH}
+  expected = File.join(recipe.path, "lib", "libyaml.a")
+  $libs.include?(expected) or raise(<<~MSG)
+    assertion failed: $libs not updated correctly:
+    #{$libs}
     should have included '#{expected}'
   MSG
 
-  unless have_library("yaml", "yaml_get_version", "yaml.h")
+  unless have_func("yaml_get_version", "yaml.h")
     raise("could not find libyaml development environment")
   end
 end

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -27,6 +27,8 @@ class Net::HTTP
   end
 end
 
+$MINI_PORTILE_STATIC_LIBS = {}
+
 class MiniPortile
   DEFAULT_TIMEOUT = 10
 
@@ -267,7 +269,15 @@ class MiniPortile
     end
   end
 
-  def mkmf_config(pkg: nil, dir: nil)
+  # pkg: the pkg-config file name (without the .pc extension)
+  # dir: inject the directory path for the pkg-config file (probably only useful for tests)
+  # static: the name of the static library archive (without the "lib" prefix or the file extension), or nil for dynamic linking
+  #
+  # we might be able to be terribly clever and infer the name of the static archive file, but
+  # unfortunately projects have so much freedom in what they can report (for name, for libs, etc.)
+  # that it feels unreliable to try to do so, so I'm preferring to just have the developer make it
+  # explicit.
+  def mkmf_config(pkg: nil, dir: nil, static: nil)
     require "mkmf"
 
     if pkg
@@ -287,8 +297,13 @@ class MiniPortile
 
       incflags = minimal_pkg_config(pcfile, "cflags-only-I")
       cflags = minimal_pkg_config(pcfile, "cflags-only-other")
-      ldflags = minimal_pkg_config(pcfile, "libs-only-L", "static")
-      libflags = minimal_pkg_config(pcfile, "libs-only-l", "static")
+      if static
+        ldflags = minimal_pkg_config(pcfile, "libs-only-L", "static")
+        libflags = minimal_pkg_config(pcfile, "libs-only-l", "static")
+      else
+        ldflags = minimal_pkg_config(pcfile, "libs-only-L")
+        libflags = minimal_pkg_config(pcfile, "libs-only-l")
+      end
     else
       output "Configuring MakeMakefile for #{@name} #{@version} (from #{path})\n"
 
@@ -298,6 +313,37 @@ class MiniPortile
       cflags = ""
       ldflags = Dir.exist?(lib_path) ? "-L#{lib_path}" : ""
       libflags = Dir.exist?(lib_path) ? "-l#{lib_name}" : ""
+    end
+
+    if static
+      libdir = lib_path
+      if pcfile
+        variables = minimal_pkg_config(pcfile, "print-variables").split("\n").map(&:strip)
+        if variables.include?("libdir")
+          libdir = minimal_pkg_config(pcfile, "variable=libdir")
+        end
+      end
+
+      #
+      # keep track of the libraries we're statically linking against, and fix up ldflags and
+      # libflags to make sure we link statically against the recipe's libaries.
+      #
+      # this avoids the unintentionally dynamically linking against system libraries, and makes sure
+      # that if multiple pkg-config files reference each other that we are able to intercept flags
+      # from dependent packages that reference the static archive.
+      #
+      $MINI_PORTILE_STATIC_LIBS[static] = libdir
+      static_ldflags = $MINI_PORTILE_STATIC_LIBS.values.map { |v| "-L#{v}" }
+      static_libflags = $MINI_PORTILE_STATIC_LIBS.keys.map { |v| "-l#{v}" }
+
+      # remove `-L#{libdir}` and `-lfoo`. we don't need them since we link against the static
+      # archive using the full path.
+      ldflags = ldflags.shellsplit.reject { |f| static_ldflags.include?(f) }.shelljoin
+      libflags = libflags.shellsplit.reject { |f| static_libflags.include?(f) }.shelljoin
+
+      # prepend the full path to the static archive to the linker flags
+      static_archive = File.join(libdir, "lib#{static}.#{$LIBEXT}")
+      libflags = [static_archive, libflags].join(" ").strip
     end
 
     # prefer this package by prepending to search paths and library flags

--- a/test/test_recipe.rb
+++ b/test/test_recipe.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../helper', __FILE__)
+
+class TestRecipe < TestCase
+  def test_path
+    recipe = MiniPortile.new("libfoo", "1.0.0")
+    assert_equal(File.expand_path(File.join(recipe.target, recipe.host, recipe.name, recipe.version)), recipe.path)
+  end
+
+  def test_lib_path
+    recipe = MiniPortile.new("libfoo", "1.0.0")
+    assert_equal(File.join(recipe.path, "lib"), recipe.lib_path)
+  end
+
+  def test_include_path
+    recipe = MiniPortile.new("libfoo", "1.0.0")
+    assert_equal(File.join(recipe.path, "include"), recipe.include_path)
+  end
+end


### PR DESCRIPTION
## the problem being addressed

v2.8.5.rc1 didn't work perfectly for Nokogiri (see https://github.com/sparklemotion/nokogiri/pull/2974). Specifically: if a system library like `libxml2.so` is installed in a default search path (e.g., this is the case for some system installations of ruby), then the linker dynamically links against the system library rather than statically linking against the packaged static archive.

## the implementation

This PR is an attempt to fix that by asking the developer to pass in the name of the static archive when choosing to statically link. For example:

```ruby
libxml2_recipe.mkmf_config(pkg: "libxml-2.0", static: "xml2")
```

In this case, MiniPortile will now:

- rewrite the linker flags to ensure we link against the packaged static archive
  - remove all `-L` and `-l` flags
  - inject the full path to the static archive, e.g. `/path/to/foopkg/1.1.1/lib/libfoo.a`
- remember what static archives it's already seen, so any subsequent pkg-config packages that reference earlier packages in a `Requires` section will also have their flags resolved correctly.

This PR also makes sure to _prepend_ to `$libs` instead of appending to it. (Since it now contains archive file paths, this seems like a sensible thing to do.) Finally, this also conditionally adds `--static` to the `pkg-config` flags only when a static build is requested with the `static:` kwarg to `mkmf_config`.

## a note on the new parameter

It may be worth noting why we ask the developer to pass in the name of the static archive root (e.g., `xml2` above). While it seems possible to infer the name of this file from the output of pkg-config, there's so much freedom in how packages can describe themselves in a pkg-config file that my confidence is low that we could handle all possible edge cases.

Just as an example, here's the libxml2 config file for a vanilla x86-64 linux system:

```
prefix=/home/flavorjones/code/oss/nokogiri/ports/x86_64-linux/libxml2/2.11.5
exec_prefix=${prefix}
libdir=/home/flavorjones/code/oss/nokogiri/ports/x86_64-linux/libxml2/2.11.5/lib
includedir=${prefix}/include
modules=1

Name: libXML
Version: 2.11.5
Description: libXML library version2.
Requires:
Libs: -L${libdir} -lxml2
Libs.private: -lz -llzma    -lm  
Cflags: -I${includedir}/libxml2 
```

A couple of notable things from this example:

- the name of the file, `libxml-2.0.pc` doesn't match the archive name
- the name of the package, `libXML`, doesn't match the archive name

The only place we can see the string we want, `"xml2"`, is in the `Libs` section, however it's possible for multiple `-l` options to appear on this line, and pkg-config will emit dependencies' libraries as well when asking for `--libs-only-l`.

It seems best for the developer to just tell us that the libflag is `-lxml2` and the static archive is `libxml2.a` by passing in `static: "xml2"`.