### PR TITLE
Eliminate "method redefined" warning

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -32,9 +32,9 @@ $MINI_PORTILE_STATIC_LIBS = {}
 class MiniPortile
   DEFAULT_TIMEOUT = 10
 
-  attr_reader :name, :version, :original_host
+  attr_reader :name, :version, :original_host, :source_directory
   attr_writer :configure_options
-  attr_accessor :host, :files, :patch_files, :target, :logger, :source_directory
+  attr_accessor :host, :files, :patch_files, :target, :logger
 
   def self.windows?
     target_os =~ /mswin|mingw/


### PR DESCRIPTION
This patch fixes the "method redefined" warning that occurs while loading the gem.

```
$ ruby -wrmini_portile2 -ep
.../mini_portile2-2.8.4/lib/mini_portile2/mini_portile.rb:97: warning: method redefined; discarding old source_directory=
```