### PR TITLE
Create release binary with cmake explicitly

### DIFF
--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -69,7 +69,8 @@ class MiniPortileCMake < MiniPortile
       "-DCMAKE_SYSTEM_NAME=#{cmake_system_name}",
       "-DCMAKE_SYSTEM_PROCESSOR=#{cpu_type}",
       "-DCMAKE_C_COMPILER=#{c_compiler}",
-      "-DCMAKE_CXX_COMPILER=#{cxx_compiler}"
+      "-DCMAKE_CXX_COMPILER=#{cxx_compiler}",
+      "-DCMAKE_BUILD_TYPE=Release"
     ]
   end
 

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -11,6 +11,7 @@ class MiniPortileCMake < MiniPortile
   def initialize(name, version, **kwargs)
     super(name, version, **kwargs)
     @cmake_command = kwargs[:cmake_command]
+    @cmake_build_type = kwargs[:cmake_build_type]
   end
 
   def configure_defaults
@@ -49,6 +50,10 @@ class MiniPortileCMake < MiniPortile
     (ENV["CMAKE"] || @cmake_command || "cmake").dup
   end
 
+  def cmake_build_type
+    (ENV["CMAKE_BUILD_TYPE"] || @cmake_build_type || "Release").dup
+  end
+
   private
 
   def generator_defaults
@@ -70,7 +75,7 @@ class MiniPortileCMake < MiniPortile
       "-DCMAKE_SYSTEM_PROCESSOR=#{cpu_type}",
       "-DCMAKE_C_COMPILER=#{c_compiler}",
       "-DCMAKE_CXX_COMPILER=#{cxx_compiler}",
-      "-DCMAKE_BUILD_TYPE=Release"
+      "-DCMAKE_BUILD_TYPE=#{cmake_build_type}",
     ]
   end
 

--- a/test/test_cmake.rb
+++ b/test/test_cmake.rb
@@ -96,7 +96,8 @@ class TestCMakeConfig < TestCMake
                   "-DCMAKE_SYSTEM_NAME=Darwin",
                   "-DCMAKE_SYSTEM_PROCESSOR=arm64",
                   "-DCMAKE_C_COMPILER=some-host-clang",
-                  "-DCMAKE_CXX_COMPILER=some-host-clang++"
+                  "-DCMAKE_CXX_COMPILER=some-host-clang++",
+                  "-DCMAKE_BUILD_TYPE=Release"
                 ],
                 recipe.configure_defaults)
             end
@@ -119,7 +120,8 @@ class TestCMakeConfig < TestCMake
                 "-DCMAKE_SYSTEM_NAME=Custom",
                 "-DCMAKE_SYSTEM_PROCESSOR=x86_64",
                 "-DCMAKE_C_COMPILER=gcc",
-                "-DCMAKE_CXX_COMPILER=g++"
+                "-DCMAKE_CXX_COMPILER=g++",
+                "-DCMAKE_BUILD_TYPE=Release"
               ],
               recipe.configure_defaults)
           end
@@ -227,7 +229,8 @@ class TestCMakeConfig < TestCMake
       "-DCMAKE_SYSTEM_NAME=Linux",
       "-DCMAKE_SYSTEM_PROCESSOR=x86_64",
       "-DCMAKE_C_COMPILER=gcc",
-      "-DCMAKE_CXX_COMPILER=g++"
+      "-DCMAKE_CXX_COMPILER=g++",
+      "-DCMAKE_BUILD_TYPE=Release"
     ]
   end
 

--- a/test/test_cmake.rb
+++ b/test/test_cmake.rb
@@ -196,6 +196,17 @@ class TestCMakeConfig < TestCMake
     end
   end
 
+  def test_cmake_build_type_configuration
+    without_env("CMAKE_BUILD_TYPE") do
+      assert_equal("Release", MiniPortileCMake.new("test", "1.0.0").cmake_build_type)
+      assert_equal("xyzzy", MiniPortileCMake.new("test", "1.0.0", cmake_build_type: "xyzzy").cmake_build_type)
+    end
+    with_env("CMAKE_BUILD_TYPE"=>"Debug") do
+      assert_equal("Debug", MiniPortileCMake.new("test", "1.0.0").cmake_build_type)
+      assert_equal("Debug", MiniPortileCMake.new("test", "1.0.0", cmake_build_type: "xyzzy").cmake_build_type)
+    end
+  end
+
   private
 
   def with_stubbed_target(os: 'linux', cpu: 'x86_64')


### PR DESCRIPTION
When I built library with the default setting, its compilation has no optimized in my environment.
I want it has release binary by default.

Ref. https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
