### PR TITLE
Add OpenBSD support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,10 @@ jobs:
             bundle exec rake ${{ matrix.task }}
 
   openbsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        task: ["test:unit", "test:examples"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,14 +131,17 @@ jobs:
       matrix:
         task: ["test:unit", "test:examples"]
     runs-on: ubuntu-latest
+    env:
+      MAKE: gmake
     steps:
     - uses: actions/checkout@v4
     - uses: vmactions/openbsd-vm@v1
       with:
+        envs: MAKE
         usesh: true
         copyback: false
         prepare: |
-          pkg_add ruby%3.1
+          pkg_add ruby%3.1 gmake cmake git pkgconf security/gnupg
           ln -sf /usr/local/bin/ruby31 /usr/local/bin/ruby
           ln -sf /usr/local/bin/bundle31 /usr/local/bin/bundle
           ln -sf /usr/local/bin/bundler31 /usr/local/bin/bundler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,33 @@ jobs:
             gem install bundler
             bundle install
             bundle exec rake ${{ matrix.task }}
+
+  openbsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: vmactions/openbsd-vm@v1
+      with:
+        usesh: true
+        copyback: false
+        prepare: |
+          pkg_add ruby%3.1
+          ln -sf /usr/local/bin/ruby31 /usr/local/bin/ruby
+          ln -sf /usr/local/bin/bundle31 /usr/local/bin/bundle
+          ln -sf /usr/local/bin/bundler31 /usr/local/bin/bundler
+          ln -sf /usr/local/bin/erb31 /usr/local/bin/erb
+          ln -sf /usr/local/bin/gem31 /usr/local/bin/gem
+          ln -sf /usr/local/bin/irb31 /usr/local/bin/irb
+          ln -sf /usr/local/bin/racc31 /usr/local/bin/racc
+          ln -sf /usr/local/bin/rake31 /usr/local/bin/rake
+          ln -sf /usr/local/bin/rbs31 /usr/local/bin/rbs
+          ln -sf /usr/local/bin/rdbg31 /usr/local/bin/rdbg
+          ln -sf /usr/local/bin/rdoc31 /usr/local/bin/rdoc
+          ln -sf /usr/local/bin/ri31 /usr/local/bin/ri
+          ln -sf /usr/local/bin/syntax_suggest31 /usr/local/bin/syntax_suggest
+          ln -sf /usr/local/bin/typeprof31 /usr/local/bin/typeprof
+        run: |
+          git config --global --add safe.directory /home/runner/work/mini_portile/mini_portile
+          gem install bundler
+          bundle install
+          bundle exec rake ${{ matrix.task }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Added
 
-- When setting the C compiler through the `MiniPortile` constructor, the preferred keyword argument is now `:cc_command`. The original `:gcc_command` is still supported. @flavorjones
-- GPG file verification error messages are captured in the raised exception. Previously these errors went to `stderr`. @flavorjones
+- When setting the C compiler through the `MiniPortile` constructor, the preferred keyword argument is now `:cc_command`. The original `:gcc_command` is still supported. (#144 by @flavorjones)
+- GPG file verification error messages are captured in the raised exception. Previously these errors went to `stderr`. (#145 by @flavorjones)
+- Add support for extracting xz-compressed tarballs on OpenBSD. (#141 by @postmodern)
 
 
 ### 2.8.6 / 2024-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - When setting the C compiler through the `MiniPortile` constructor, the preferred keyword argument is now `:cc_command`. The original `:gcc_command` is still supported. (#144 by @flavorjones)
 - GPG file verification error messages are captured in the raised exception. Previously these errors went to `stderr`. (#145 by @flavorjones)
 - Add support for extracting xz-compressed tarballs on OpenBSD. (#141 by @postmodern)
+- Add OpenBSD support to the experimental method `MakeMakefile#mkmf_config`. (#141 by @flavorjones)
 
 
 ### 2.8.6 / 2024-04-14

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -320,10 +320,8 @@ class MiniPortile
     if static
       libdir = lib_path
       if pcfile
-        variables = minimal_pkg_config(pcfile, "print-variables").split("\n").map(&:strip)
-        if variables.include?("libdir")
-          libdir = minimal_pkg_config(pcfile, "variable=libdir")
-        end
+        pcfile_libdir = minimal_pkg_config(pcfile, "variable=libdir").strip
+        libdir = pcfile_libdir unless pcfile_libdir.empty?
       end
 
       #


### PR DESCRIPTION
* Add OpenBSD to the CI matrix.
* Workaround OpenBSD's `tar` not supporting the `-J` option by using `xzcat $file | tar xf - -C $dest`.