### PR TITLE
ci: pin to macos-13 when necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,15 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head"]
+        ruby: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "head"]
+        exclude:
+          # I can't figure out how to install these on macos through setup-ruby
+          - ruby: "2.3"
+            platform: "macos-latest"
+          - ruby: "2.4"
+            platform: "macos-latest"
+          - ruby: "2.5"
+            platform: "macos-latest"
     runs-on: ${{ matrix.platform }}
     steps:
       - name: configure git crlf on windows
@@ -48,7 +56,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        # use macos-13 (not 14) because libyaml 0.2.5 doesn't have up-to-date config.guess and config.sub
+        platform: [ubuntu-latest, windows-latest, macos-13]
         ruby: ["3.1"]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Older rubies are not available on MacOS 14 through setup-ruby; and the libyaml 0.2.5 example does not have up-to-date config.guess/config.sub files to handle arm64-darwin.