### PR TITLE
Add `cxx_cmd` which parallels `cc_cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,22 +85,29 @@ system-wide installation.
 
 Some keyword arguments can be passed to the constructor to configure the commands used:
 
-#### `cc_command`
+#### `cc_command` and `cxx_command`
 
-The compiler command that is used is configurable, and in order of preference will use:
+The C compiler command that is used is configurable, and in order of preference will use:
 
 - the `CC` environment variable (if present)
 - the `:cc_command` keyword argument passed in to the constructor
 - `RbConfig::CONFIG["CC"]`
 - `"gcc"`
 
-You can pass it in like so:
+The C++ compiler is similarly configuratble, and in order of preference will use:
+
+- the `CXX` environment variable (if present)
+- the `:cxx_command` keyword argument passed in to the constructor
+- `RbConfig::CONFIG["CXX"]`
+- `"g++"`
+
+You can pass your compiler commands to the MiniPortile constructor:
 
 ``` ruby
-MiniPortile.new("libiconv", "1.13.1", cc_command: "cc")
+MiniPortile.new("libiconv", "1.13.1", cc_command: "clang", cxx_command: "clang++")
 ```
 
-For backwards compatibility, the constructor also supports a keyword argument `:gcc_command`.
+(For backwards compatibility, the constructor also supports a keyword argument `:gcc_command` for the C compiler.)
 
 #### `make_command`
 

--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -107,6 +107,7 @@ class MiniPortile
     @source_directory = nil
 
     @cc_command = kwargs[:cc_command] || kwargs[:gcc_command]
+    @cxx_command = kwargs[:cxx_command]
     @make_command = kwargs[:make_command]
     @open_timeout = kwargs[:open_timeout] || DEFAULT_TIMEOUT
     @read_timeout = kwargs[:read_timeout] || DEFAULT_TIMEOUT
@@ -376,6 +377,10 @@ class MiniPortile
     (ENV["CC"] || @cc_command || RbConfig::CONFIG["CC"] || "gcc").dup
   end
   alias :gcc_cmd :cc_cmd
+
+  def cxx_cmd
+    (ENV["CXX"] || @cxx_command || RbConfig::CONFIG["CXX"] || "g++").dup
+  end
 
   def make_cmd
     (ENV["MAKE"] || @make_command || ENV["make"] || "make").dup

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -67,47 +67,19 @@ class MiniPortileCMake < MiniPortile
   end
 
   def cmake_compile_flags
-    c_compiler, cxx_compiler = find_c_and_cxx_compilers(host)
+    # RbConfig::CONFIG['CC'] and RbConfig::CONFIG['CXX'] can contain additional flags, for example
+    # "clang++ -std=gnu++11" or "clang -fdeclspec". CMake is just looking for the command name.
+    cc_compiler = cc_cmd.split.first
+    cxx_compiler = cxx_cmd.split.first
 
     # needed to ensure cross-compilation with CMake targets the right CPU and compilers
     [
       "-DCMAKE_SYSTEM_NAME=#{cmake_system_name}",
       "-DCMAKE_SYSTEM_PROCESSOR=#{cpu_type}",
-      "-DCMAKE_C_COMPILER=#{c_compiler}",
+      "-DCMAKE_C_COMPILER=#{cc_compiler}",
       "-DCMAKE_CXX_COMPILER=#{cxx_compiler}",
       "-DCMAKE_BUILD_TYPE=#{cmake_build_type}",
     ]
-  end
-
-  def find_compiler(compilers)
-    compilers.find { |binary| which(binary) }
-  end
-
-  # configure automatically searches for the right compiler based on the
-  # `--host` parameter.  However, CMake doesn't have an equivalent feature.
-  # Search for the right compiler for the target architecture using
-  # some basic heruistics.
-  def find_c_and_cxx_compilers(host)
-    c_compiler = ENV["CC"]
-    cxx_compiler = ENV["CXX"]
-
-    if MiniPortile.darwin?
-      c_compiler ||= 'clang'
-      cxx_compiler ||='clang++'
-    elsif MiniPortile.freebsd?
-      c_compiler ||= 'cc'
-      cxx_compiler ||= 'c++'
-    else
-      c_compiler ||= 'gcc'
-      cxx_compiler ||= 'g++'
-    end
-
-    c_platform_compiler = "#{host}-#{c_compiler}"
-    cxx_platform_compiler = "#{host}-#{cxx_compiler}"
-    c_compiler = find_compiler([c_platform_compiler, c_compiler])
-    cxx_compiler = find_compiler([cxx_platform_compiler, cxx_compiler])
-
-    [c_compiler, cxx_compiler]
   end
 
   # Full list: https://gitlab.kitware.com/cmake/cmake/-/blob/v3.26.4/Modules/CMakeDetermineSystem.cmake?ref_type=tags#L12-31

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,11 @@ require 'fileutils'
 require 'erb'
 require 'mini_portile2'
 
+puts "#{__FILE__}:#{__LINE__}: relevant RbConfig::CONFIG values:"
+%w[target_os target_cpu CC CXX].each do |key|
+  puts "- #{key}: #{RbConfig::CONFIG[key].inspect}"
+end
+
 class TestCase < Minitest::Test
   include Minitest::Hooks
 

--- a/test/test_cook.rb
+++ b/test/test_cook.rb
@@ -98,6 +98,18 @@ class TestCookConfiguration < TestCase
       assert_equal("asdf", MiniPortile.new("test", "1.0.0", gcc_command: "xyzzy").gcc_cmd)
     end
   end
+
+  def test_cxx_command_configuration
+    without_env("CXX") do
+      expected_compiler = RbConfig::CONFIG["CXX"] || "g++"
+      assert_equal(expected_compiler, MiniPortile.new("test", "1.0.0").cxx_cmd)
+      assert_equal("xyzzy", MiniPortile.new("test", "1.0.0", cxx_command: "xyzzy").cxx_cmd)
+    end
+    with_env("CXX"=>"asdf") do
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0").cxx_cmd)
+      assert_equal("asdf", MiniPortile.new("test", "1.0.0", cxx_command: "xyzzy").cxx_cmd)
+    end
+  end
 end
 
 


### PR DESCRIPTION
Add a `cxx_cmd`. Use it for configuring CMake, removing the logic added in #130 for host-specific binary detection.

Related to #141.
