### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/mini_portile

### DIFF
--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -40,4 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-hooks", "~> 1.5"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "webrick", "~> 1.7"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/main/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/mini_portile which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/