### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/mini_portile2.gemspec
+++ b/mini_portile2.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.metadata["changelog_uri"] = spec.homepage + "/blob/main/CHANGELOG.md"
+  spec.metadata["funding_uri"] = "https://github.com/sponsors/flavorjones"
 end


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.