### PR TITLE
ci: brew install libiconv for test-examples on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
   test-examples:
     env:
       MAKEFLAGS: -j2
+      LDFLAGS: "-L/usr/local/opt/libiconv/lib" # for macos-13, sigh
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +72,7 @@ jobs:
         with:
           apt-get: _update_ build-essential cmake
           mingw: _upgrade_ cmake
+          brew: libiconv
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - uses: actions/cache@v4


### PR DESCRIPTION
This started failing suddenly, I imagine because Github's base container removed libiconv or something.

example: https://github.com/flavorjones/mini_portile/actions/runs/12081054688/job/33689444541#step:6:193