### PR TITLE
dev: add logger to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,17 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "net-ftp" if Gem::Requirement.new("> 3.1.0.dev").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+group :development do
+  gem "minitar", "0.9"
+  gem "minitest", "~> 5.15" # open range for ruby 2.3 support
+  gem "minitest-hooks", "1.5.2"
+  gem "rake", "13.2.1"
+  if RUBY_VERSION >= "3.4"
+    gem "webrick", git: "https://github.com/ruby/webrick" # shouldn't be necessary to pin once webrick 1.8.2 or 1.9.0 is released
+  else
+    gem "webrick"
+  end
 
-gem "minitar", "0.9"
-gem "minitest", "~> 5.15" # open range for ruby 2.3 support
-gem "minitest-hooks", "1.5.2"
-gem "rake", "13.2.1"
-if RUBY_VERSION >= "3.4"
-  gem "webrick", git: "https://github.com/ruby/webrick" # shouldn't be necessary to pin once webrick 1.8.2 or 1.9.0 is released
-else
-  gem "webrick"
+  gem "net-ftp" if Gem::Requirement.new("> 3.1.0.dev").satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem "logger", "1.6.5" if Gem::Requirement.new("> 3.5.0.dev").satisfied_by?(Gem::Version.new(RUBY_VERSION))
 end


### PR DESCRIPTION
Logger has been moved out of the default gems in Ruby 3.5, which was causing failures in the "upstream" CI jobs, e.g. https://github.com/flavorjones/mini_portile/actions/runs/12825003621/job/35762153079#step:5:29

Also group the gems in the Gemfile under the "development" group