### PR TITLE
ci: windows images no longer support older cmake versions

### DIFF
--- a/test/assets/test-cmake-1.0/CMakeLists.txt
+++ b/test/assets/test-cmake-1.0/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists files in this project can
 # refer to the root source directory of the project as ${HELLO_SOURCE_DIR} and
 # to the root binary directory of the project as ${HELLO_BINARY_DIR}.
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 3.5)
 project (HELLO)
 add_executable (hello hello.c)
 install (TARGETS hello DESTINATION bin)


### PR DESCRIPTION
"Compatibility with CMake < 3.5 has been removed from CMake."