### PR TITLE
feat: support building with CMake on GNU/Hurd

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -72,6 +72,10 @@ class MiniPortile
     target_os =~ /solaris/
   end
 
+  def self.hurd?
+    target_os == 'gnu'
+  end
+
   def self.target_os
     RbConfig::CONFIG['target_os']
   end

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -98,6 +98,8 @@ class MiniPortileCMake < MiniPortile
       'OpenBSD'
     elsif MiniPortile.solaris?
       'SunOS'
+    elsif MiniPortile.hurd?
+      'GNU'
     else
       raise "Unable to set CMAKE_SYSTEM_NAME for #{MiniPortile.target_os}"
     end


### PR DESCRIPTION
Provide the support for building using CMake on GNU/Hurd; most of the toolchain setup works, it only needs `CMAKE_SYSTEM_NAME`:
- add an helper `MiniPortile.hurd` method to detect the Hurd; since the target_os is "gnu" exactly, and that other GNU-based OSes had "gnu" in their name, do an exact check rather than a `/match/` as done for the other helper methods
- use "GNU" as `CMAKE_SYSTEM_NAME` on the Hurd

The existing tests now pass on the Hurd.