### PR TITLE
Only load what is required from `cgi`

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -5,7 +5,8 @@ require 'fileutils'
 require 'tempfile'
 require 'digest'
 require 'open-uri'
-require 'cgi'
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 require 'rbconfig'
 require 'shellwords'
 require 'open3'


### PR DESCRIPTION
Another one (:

In Ruby 3.5 most of the `cgi` gem will be removed. Only the various escape/unescape methods will be retained by default.

On older versions, require `"cgi/util"` is needed because the unescape* methods don't work otherwise. Doing it that way works since Ruby 2.3, which conveniently is the minimum supported ruby version here.

https://bugs.ruby-lang.org/issues/21258