### PR TITLE
Support cygwin.

### DIFF
--- a/lib/mini_portile2/mini_portile.rb
+++ b/lib/mini_portile2/mini_portile.rb
@@ -516,7 +516,7 @@ class MiniPortile
   #
   #   which('ruby') #=> /usr/bin/ruby
   def which(cmd)
-    exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    exts = [''] + (ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : [])
     ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
       exts.each { |ext|
         exe = File.join(path, "#{cmd}#{ext}")


### PR DESCRIPTION
Because the cygwin has only "xzcat" instead of "xzcat$ext", search first also command without ext when ENV["PATHEXT"] is defined.

----

The following error occurred while installing Nokogiri on Cygwin:

```console
$ gem install nokogiri
Building native extensions. This could take a while...
ERROR:  Error installing nokogiri:
        ERROR: Failed to build gem native extension.
...
/cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:558:in `xzcat_exe': xzcat not found (RuntimeError)
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:569:in `tar_command'
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:580:in `extract_file'
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:141:in `block in extract'
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:139:in `each'
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:139:in `extract'
        from /cygdrive/c/Users/kou/HOME/.gem/ruby/3.2.0/gems/mini_portile2-2.8.9/lib/mini_portile2/mini_portile.rb:234:in `cook'
        from extconf.rb:550:in `block (2 levels) in process_recipe'
        from extconf.rb:329:in `chdir'
        from extconf.rb:329:in `chdir_for_build'
        from extconf.rb:550:in `block in process_recipe'
        from <internal:kernel>:90:in `tap'
        from extconf.rb:448:in `process_recipe'
        from extconf.rb:892:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /home/kou/.gem/ruby/3.2.0/extensions/x86_64-cygwin/3.2.0/nokogiri-1.18.9/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /home/kou/.gem/ruby/3.2.0/gems/nokogiri-1.18.9 for inspection.
Results logged to /home/kou/.gem/ruby/3.2.0/extensions/x86_64-cygwin/3.2.0/nokogiri-1.18.9/gem_make.out
```

Cygwin has only `xzcat`. There are no `xzcat$ext`:

```console
$ stat -c %N /usr/bin/xzcat*
'/usr/bin/xzcat' -> 'xz.exe'
```
